### PR TITLE
Fix cash payment with OTP off + localize delivery/pickup banner & order modal

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -482,6 +482,14 @@ function CheckoutContent() {
     // for notifications if provided.
     if (!otpRequired) {
       setPhoneVerified(true);
+      // Even without OTP we must still check whether this phone is a trusted
+      // (cash-allowed) customer — otherwise the cash payment option would never
+      // appear when OTP is turned off for pickup/delivery.
+      if ((orderType === "pickup" || orderType === "delivery") && customerPhone.trim()) {
+        checkTrustedCustomer(restaurantId, normalizePhone(customerPhone))
+          .then(setIsTrustedCustomer)
+          .catch(() => {});
+      }
       setStep("confirm");
       return;
     }


### PR DESCRIPTION
## Summary

Two guest-checkout fixes:

### 1. Cash payment option never appeared when OTP is disabled
The cash payment button is gated on `isTrustedCustomer`, which was only set **after OTP verification** (or for already-verified returning guests). When a restaurant turns **OTP off** for pickup/delivery, `handleDetailsSubmit` took the `!otpRequired` branch and jumped straight to the confirm step — so `checkTrustedCustomer` never ran and the cash option never showed for VIP/trusted customers.

This explained the "works in dev, not in production" report: dev had OTP on (verify step ran the trusted check), while the production restaurant had OTP off.

**Fix:** the no-OTP branch now also runs `checkTrustedCustomer` for pickup/delivery when a phone is entered, so trusted customers get the cash option regardless of the OTP setting.

### 2. Missing translations in the delivery/pickup info banner & order type modal
The batch fulfillment banner and the order details modal rendered weekday names, dates and several labels (Order details, Delivery, Pickup, Scan QR) in English regardless of the selected locale. Day names came from the server (English-only) and `formatDateLabel` was hard-coded to `en-US`.

- `formatDateLabel` is now locale-aware (en/fr/he, incl. Today/Tomorrow) + new `formatWeekday` helper
- Banner/modal derive localized weekdays from dates instead of server English strings
- Translated the modal labels via i18n (added `orderDetails`, `scanQR` keys)

## Validation
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (no new warnings)

## Notes
- The `restaurantId` passed to `checkTrustedCustomer` is the numeric id from the checkout URL, which resolves correctly on custom domains too.
- If cash still doesn't appear on a custom domain **with OTP on**, the next suspect is the backend `check-trusted` / `by-domain` resolution (separate repo).

https://claude.ai/code/session_0141Y3Nt9p8KLaR1rHT6sn4C

---
_Generated by [Claude Code](https://claude.ai/code/session_0141Y3Nt9p8KLaR1rHT6sn4C)_