### PR TITLE
feat(confirmation): show courier + ETA delivery card

### DIFF
--- a/components/ConfirmationDeliveryCard.tsx
+++ b/components/ConfirmationDeliveryCard.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { OrderDeliveryInfo, OrderType } from "@/lib/types";
+import { useI18n } from "@/lib/i18n";
+
+type Props = {
+  delivery?: OrderDeliveryInfo | null;
+  orderType?: OrderType;
+};
+
+/**
+ * Formats an ETA value for display. Accepts either an ISO8601 timestamp or a
+ * bare "HH:MM" string and returns a locale-aware "HH:MM". Falls back to the
+ * raw value if it can't be parsed so we never show "Invalid Date".
+ */
+function formatEta(value?: string): string | null {
+  if (!value) return null;
+  // Bare "HH:MM" — show as-is.
+  if (/^\d{1,2}:\d{2}$/.test(value)) return value;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+/**
+ * ConfirmationDeliveryCard shows courier + ETA info for delivery orders on the
+ * post-order confirmation page. Every field is gated on presence, and the
+ * whole card disappears when there's nothing to show — so it stays invisible
+ * until the backend starts populating `external_metadata.delivery`.
+ */
+export function ConfirmationDeliveryCard({ delivery, orderType }: Props) {
+  const { t } = useI18n();
+
+  if (orderType !== "delivery" || !delivery) return null;
+
+  const { courierName, courierPhone, note } = delivery;
+  const etaStart = formatEta(delivery.etaStart);
+  const etaEnd = formatEta(delivery.etaEnd);
+  const eta = etaStart && etaEnd ? `${etaStart} – ${etaEnd}` : etaStart || etaEnd;
+
+  // Nothing worth rendering — bail so we don't show an empty card.
+  if (!courierName && !courierPhone && !eta && !note) return null;
+
+  const telHref = courierPhone ? `tel:${courierPhone.replace(/\s/g, "")}` : null;
+
+  return (
+    <div className="card p-4 space-y-3">
+      <h3 className="text-sm font-semibold text-[var(--text)]">
+        {t("deliveryInfoTitle")}
+      </h3>
+
+      <div className="space-y-2.5">
+        {courierName && (
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-[var(--surface-subtle)] flex items-center justify-center text-sm font-bold text-brand">
+              {courierName.trim().charAt(0).toUpperCase()}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-[var(--text-muted)]">{t("courierName")}</p>
+              <p className="text-sm font-medium truncate">{courierName}</p>
+            </div>
+          </div>
+        )}
+
+        {telHref && (
+          <a
+            href={telHref}
+            className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[var(--surface-subtle)] hover:bg-brand/10 transition text-sm"
+          >
+            <span className="text-[var(--text-muted)]">{t("callCourier")}</span>
+            <span className="text-brand font-medium" dir="ltr">{courierPhone}</span>
+          </a>
+        )}
+
+        {eta && (
+          <div className="px-3 py-2.5 rounded-lg bg-[var(--surface-subtle)]">
+            <p className="text-xs text-[var(--text-muted)] uppercase tracking-wide">
+              {t("eta")}
+            </p>
+            <p className="text-sm font-medium text-[var(--text)]">{eta}</p>
+          </div>
+        )}
+
+        {note && (
+          <div className="px-3 py-2.5 rounded-lg bg-[var(--surface-subtle)] border-l-2 border-brand">
+            <p className="text-sm text-[var(--text)]">{note}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/ConfirmationPageClient.tsx
+++ b/components/ConfirmationPageClient.tsx
@@ -6,6 +6,7 @@ import { initPayment } from "@/services/api";
 import type { ConfirmationConfig, OrderResponse } from "@/lib/types";
 import { useI18n } from "@/lib/i18n";
 import { ConfirmationActions, ConfirmationFAQList, ConfirmationHeader, DEFAULT_CONFIRMATION_CONFIG } from "@/components/ConfirmationActions";
+import { ConfirmationDeliveryCard } from "@/components/ConfirmationDeliveryCard";
 
 type Props = {
   order: OrderResponse;
@@ -99,6 +100,10 @@ export function ConfirmationPageClient({
           </div>
         )}
       </div>
+
+      {/* Courier / ETA info for delivery orders. Renders nothing until the
+          backend populates external_metadata.delivery. */}
+      <ConfirmationDeliveryCard delivery={order.delivery} orderType={order.orderType} />
 
       {paymentNeeded && (
         <div className="space-y-2">

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -125,6 +125,10 @@ const translations: Record<Locale, Record<string, string>> = {
     orderHistory: "Order History",
     yourOrders: "Your Orders",
     viewPastOrders: "View Your Orders",
+    deliveryInfoTitle: "Your delivery",
+    courierName: "Courier",
+    callCourier: "Call the driver",
+    eta: "Estimated arrival",
     enterPhoneToViewOrders: "Enter your phone number to view your order history",
     noOrdersFound: "No orders found for this phone number",
     // Menu & Search
@@ -488,6 +492,10 @@ const translations: Record<Locale, Record<string, string>> = {
     orderHistory: "היסטוריית הזמנות",
     yourOrders: "ההזמנות שלך",
     viewPastOrders: "צפה בהזמנות שלך",
+    deliveryInfoTitle: "המשלוח שלך",
+    courierName: "שליח",
+    callCourier: "התקשר לשליח",
+    eta: "זמן הגעה משוער",
     enterPhoneToViewOrders: "הזן את מספר הטלפון שלך כדי לצפות בהיסטוריית ההזמנות",
     noOrdersFound: "לא נמצאו הזמנות עבור מספר טלפון זה",
     // Menu & Search
@@ -851,6 +859,10 @@ const translations: Record<Locale, Record<string, string>> = {
     orderHistory: "Historique des commandes",
     yourOrders: "Vos commandes",
     viewPastOrders: "Voir vos commandes",
+    deliveryInfoTitle: "Votre livraison",
+    courierName: "Livreur",
+    callCourier: "Appeler le livreur",
+    eta: "Heure d'arrivée estimée",
     enterPhoneToViewOrders: "Entrez votre numéro de téléphone pour voir l'historique de vos commandes",
     noOrdersFound: "Aucune commande trouvée pour ce numéro de téléphone",
     // Menu & Search

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -253,6 +253,21 @@ export type OrderPayload = {
   scheduledPickupWindowEnd?: string;   // "HH:MM"
 };
 
+/**
+ * Delivery / courier info surfaced on the confirmation page.
+ *
+ * Populated by the server into `external_metadata.delivery` on the public
+ * order response (snake_case keys). The card only renders the fields that are
+ * present, so the page degrades gracefully before the backend ships these.
+ */
+export type OrderDeliveryInfo = {
+  courierName?: string;
+  courierPhone?: string;
+  etaStart?: string; // ISO8601 timestamp or "HH:MM"
+  etaEnd?: string; // ISO8601 timestamp or "HH:MM"
+  note?: string; // free-text note from the restaurant owner
+};
+
 export type OrderResponse = {
   orderId: string;
   total: number;
@@ -260,6 +275,7 @@ export type OrderResponse = {
   orderSource?: OrderSource;
   orderType?: OrderType;
   externalMetadata?: Record<string, any> | null;
+  delivery?: OrderDeliveryInfo | null;
   orderStatus: OrderStatus;
   paymentStatus: PaymentStatus;
   receiptToken?: string;

--- a/services/api.ts
+++ b/services/api.ts
@@ -3,6 +3,7 @@ import {
   MenuItem,
   MenuResponse,
   ModifierSet,
+  OrderDeliveryInfo,
   OrderPayload,
   OrderResponse,
   OrderSource,
@@ -399,12 +400,36 @@ export async function fetchOrder(orderId: string, restaurantId: string): Promise
     orderSource: data.order.order_source,
     orderType: data.order.order_type,
     externalMetadata: data.order.external_metadata,
+    delivery: parseDeliveryInfo(data.order),
     orderStatus,
     paymentStatus,
     receiptToken: data.order.receipt_token,
     tableCode: data.order.table_code || undefined,
     sessionId: data.order.session_id || undefined,
   };
+}
+
+/**
+ * Extracts courier / delivery info for the confirmation page from a public
+ * order payload. The server places these under `external_metadata.delivery`
+ * (preferred) but we also accept top-level `courier_*` fields for forward
+ * compatibility. Returns null when there's nothing to show so the UI stays
+ * empty rather than rendering a blank card.
+ */
+function parseDeliveryInfo(order: any): OrderDeliveryInfo | null {
+  const src = order?.external_metadata?.delivery ?? order?.delivery ?? order;
+  const courierName = src?.courier_name ?? src?.courierName;
+  const courierPhone = src?.courier_phone ?? src?.courierPhone;
+  const etaStart = src?.eta_start ?? src?.etaStart;
+  const etaEnd = src?.eta_end ?? src?.etaEnd;
+  const note = src?.note ?? src?.delivery_note ?? src?.deliveryNote;
+  const info: OrderDeliveryInfo = {};
+  if (courierName) info.courierName = String(courierName);
+  if (courierPhone) info.courierPhone = String(courierPhone);
+  if (etaStart) info.etaStart = String(etaStart);
+  if (etaEnd) info.etaEnd = String(etaEnd);
+  if (note) info.note = String(note);
+  return Object.keys(info).length > 0 ? info : null;
 }
 
 // ============ Payment ============


### PR DESCRIPTION
## Courier / delivery info on the confirmation page

### What's here
- **`OrderResponse`** gains `delivery`; **`fetchOrder`** parses `external_metadata.delivery` (with top-level `courier_*` as a fallback) via `parseDeliveryInfo`.
- New **`ConfirmationDeliveryCard`** on the confirmation page: courier name, **tap-to-call phone**, **ETA window**, and the owner's note — each gated on data presence, so the card stays hidden until the backend populates it.
- **i18n** (en/he/fr).

Degrades gracefully: nothing renders for non-delivery orders or before the server returns delivery data. The server only discloses these fields when the owner opts in (see the `server` PR).

### Validation
`tsc --noEmit` clean · `next lint` clean (only pre-existing warnings).

Pairs with the `server` and `admin` PRs.

https://claude.ai/code/session_01KnbLrtVTMFt83xeqtABW7F

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnbLrtVTMFt83xeqtABW7F)_