### PR TITLE
fix(combo): drop step ordinal from preview chips to avoid confusion

### DIFF
--- a/components/ComboDetailsModal.tsx
+++ b/components/ComboDetailsModal.tsx
@@ -164,7 +164,7 @@ export function ComboDetailsModal({
                     {t("comboStepsLabel")}
                   </p>
                   <div className="flex flex-wrap gap-1.5">
-                    {combo.steps.map((step, idx) => {
+                    {combo.steps.map((step) => {
                       const isPreset = step.items.length === 1 && step.minPicks > 0;
                       return (
                         <span
@@ -188,7 +188,7 @@ export function ComboDetailsModal({
                               <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                             </svg>
                           )}
-                          <span>{idx + 1} · {step.name}</span>
+                          <span>{step.name}</span>
                           {isPreset && step.minPicks > 1 && (
                             <span className="opacity-80 tabular-nums">×{step.minPicks}</span>
                           )}


### PR DESCRIPTION
Customers read the leading step number (e.g. "3 · Viandes") as a quantity ("3 meats"). The chip used a number-before-name for step order and a number-after-name (×N) for actual count, two opposite meanings in the same visual treatment. Reading order already conveys sequence and these preview chips aren't tappable navigation, so the ordinal added nothing but ambiguity. Now the only number shown is a real quantity.