### PR TITLE
refactor(web): make special-instructions (notes) field per-item only

### DIFF
--- a/components/ItemModal.tsx
+++ b/components/ItemModal.tsx
@@ -18,9 +18,6 @@ import {
 
 type Props = {
   item?: MenuItem | null;
-  /** Restaurant-wide default for the "special instructions" field. The item's
-   *  own allowNotes overrides it when set. Defaults to true. */
-  restaurantAllowNotes?: boolean;
   onClose: () => void;
   onAdd: (item: MenuItem, quantity: number, note?: string, modifiers?: MenuItemModifier[], selectedVariantId?: number, selectedVariantName?: string, selectedVariantPrice?: number) => void;
 };
@@ -67,7 +64,7 @@ const IMAGE_HEIGHT_PX = 280;
  * After the user scrolls past the image, a sticky title bar fades in at the
  * top showing the item name — matching the Wolt pattern in the screenshot.
  */
-export function ItemModal({ item, restaurantAllowNotes = true, onClose, onAdd }: Props) {
+export function ItemModal({ item, onClose, onAdd }: Props) {
   const { t, direction, locale } = useI18n();
   const itemName = item ? tField(item, "name", locale) : "";
   const itemDescription = item ? tField(item, "description", locale) : "";
@@ -77,9 +74,9 @@ export function ItemModal({ item, restaurantAllowNotes = true, onClose, onAdd }:
   // a size-less item is shown. Empty when unconfigured.
   const itemPortion = item ? deriveItemPortion(item, locale) : { label: "", fromVariants: false };
   const showTitlePortion = !!itemPortion.label && !itemPortion.fromVariants;
-  // Whether to show the "special instructions" field: per-item override wins,
-  // otherwise fall back to the restaurant-wide default.
-  const notesEnabled = item?.allowNotes ?? restaurantAllowNotes;
+  // Whether to show the "special instructions" field. Per-item flag; default
+  // (null/undefined) shows it.
+  const notesEnabled = item?.allowNotes ?? true;
   const [qty, setQty] = useState(1);
   const [note, setNote] = useState("");
   const [selectedModifiers, setSelectedModifiers] = useState<Record<string, boolean>>({});

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -1003,7 +1003,6 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
       {/* Item Modal */}
       <ItemModal
         item={selectedItem}
-        restaurantAllowNotes={restaurant.allowItemNotes ?? true}
         onClose={() => setSelectedItem(null)}
         onAdd={handleAddToCart}
       />

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -36,8 +36,8 @@ export type MenuItem = {
   itemType?: ItemType;
   /** Combo steps (only present when itemType === 'combo'). */
   comboSteps?: ComboStep[];
-  /** Per-item override for the "special instructions" field. undefined/null =
-   *  inherit the restaurant default (Restaurant.allowItemNotes); true/false = force. */
+  /** Per-item toggle for the "special instructions" field. undefined/null =
+   *  default (shown); false = hidden; true = shown. */
   allowNotes?: boolean | null;
   modifiers?: MenuItemModifier[];
   /** Square-compatible modifier sets. Use these when present. */
@@ -426,7 +426,6 @@ export type Restaurant = {
   serviceMode?: "counter" | "table"; // counter = day mode (customer picks up), table = night mode (waiter delivers)
   rushMode?: boolean; // When true, restaurant is temporarily paused
   tipsEnabled?: boolean; // When false, skip the tip step for customers
-  allowItemNotes?: boolean; // Restaurant-wide default for the item "special instructions" field; per-item allowNotes overrides it
   // OTP mode for guest checkout (pickup/delivery):
   //   "required" — phone + code (default, current behaviour)
   //   "skip"     — no code at all, phone optional (notifications only)

--- a/services/api.ts
+++ b/services/api.ts
@@ -89,7 +89,6 @@ export async function fetchRestaurant(idOrSlug: string): Promise<Restaurant> {
     serviceMode: data.restaurant.service_mode || undefined,
     rushMode: data.restaurant.rush_mode ?? false,
     tipsEnabled: data.restaurant.tips_enabled ?? true,
-    allowItemNotes: data.restaurant.allow_item_notes ?? true,
     otpMode: data.restaurant.otp_mode === 'skip' ? 'skip' : 'required',
     schedulingEnabled: data.restaurant.scheduling_enabled ?? false,
     schedulingMinDaysAhead: data.restaurant.scheduling_min_days_ahead ?? 1,


### PR DESCRIPTION
## What
Resolves the guest "special instructions" field **strictly per-item** — drops the
restaurant-wide default.

- `ItemModal` computes `notesEnabled = item.allowNotes ?? true` (per-item flag;
  default shown).
- Removes `Restaurant.allowItemNotes` (type + `fetchRestaurant` mapping) and the
  `restaurantAllowNotes` prop on `ItemModal`.

## Why
Product decision: per-item only, default on. Pairs with the server and admin
notes-per-item-only PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)