### PR TITLE
feat(web): live footer + custom-page preview in website builder

### DIFF
--- a/app/r/[restaurantId]/[page]/page.tsx
+++ b/app/r/[restaurantId]/[page]/page.tsx
@@ -1,9 +1,6 @@
 import { fetchRestaurant } from "@/services/api";
-import { SectionRenderer } from "@/components/sections/SectionRenderer";
-import { SiteFooter } from "@/components/SiteFooter";
+import { CustomPageClient } from "@/components/CustomPageClient";
 import { notFound } from "next/navigation";
-import Link from "next/link";
-import Image from "next/image";
 
 export const dynamic = "force-dynamic";
 
@@ -20,18 +17,24 @@ const RESERVED = new Set([
 
 type PageProps = {
   params: { restaurantId: string; page: string };
+  searchParams: { [key: string]: string | string[] | undefined };
 };
 
-export default async function DynamicPage({ params }: PageProps) {
+export default async function DynamicPage({ params, searchParams }: PageProps) {
   if (RESERVED.has(params.page)) {
     notFound();
   }
 
+  // Inside the foodyadmin builder the page is loaded with ?preview=1 and the
+  // real content arrives over postMessage. A freshly-created page may not be
+  // published yet (no meta, no sections in the live data), so we must NOT 404
+  // in preview — render the client shell and let the draft populate it.
+  const isPreview = searchParams?.preview !== undefined;
+
   try {
     const restaurant = await fetchRestaurant(params.restaurantId);
-    const slug = restaurant.slug || String(restaurant.id);
 
-    // Filter sections for this page
+    // Filter sections for this page (live data — preview overrides client-side).
     const pageSections = (restaurant.websiteSections || []).filter(
       (s) => s.page === params.page
     );
@@ -42,7 +45,7 @@ export default async function DynamicPage({ params }: PageProps) {
     const pageMeta = (restaurant.websiteConfig?.pages || []).find(
       (p) => p.slug === params.page
     );
-    if (!pageMeta && pageSections.length === 0) {
+    if (!pageMeta && pageSections.length === 0 && !isPreview) {
       notFound();
     }
 
@@ -50,54 +53,11 @@ export default async function DynamicPage({ params }: PageProps) {
       pageMeta?.label || params.page.charAt(0).toUpperCase() + params.page.slice(1);
 
     return (
-      <div className="min-h-screen bg-[var(--bg-page)] text-[var(--text)]">
-        {/* Nav Bar */}
-        <nav className="sticky top-0 z-40 bg-[var(--surface)]/95 backdrop-blur-md border-b border-[var(--divider)]">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Link href={`/r/${slug}`} className="flex items-center gap-3">
-                {restaurant.logoUrl && (
-                  <Image
-                    src={restaurant.logoUrl}
-                    alt={restaurant.name}
-                    width={40}
-                    height={40}
-                    className="rounded-full object-cover"
-                  />
-                )}
-                <span className="font-bold text-lg">{restaurant.name}</span>
-              </Link>
-            </div>
-            <Link
-              href={`/r/${slug}/order`}
-              className="px-5 py-2.5 rounded-full bg-brand text-white font-semibold text-sm hover:opacity-90 transition-opacity"
-            >
-              Order Now
-            </Link>
-          </div>
-        </nav>
-
-        {/* Page Title */}
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
-          <h1 className="text-3xl font-bold">{pageTitle}</h1>
-        </div>
-
-        {/* Sections */}
-        <div className="max-w-6xl mx-auto px-4 sm:px-6">
-          {pageSections.length > 0 ? (
-            <SectionRenderer sections={pageSections} restaurant={restaurant} />
-          ) : (
-            <p className="py-16 text-center text-[var(--text-soft)]">
-              Cette page n&apos;a pas encore de contenu.
-            </p>
-          )}
-        </div>
-
-        {/* Site-wide footer */}
-        <div className="mt-16">
-          <SiteFooter restaurant={restaurant} />
-        </div>
-      </div>
+      <CustomPageClient
+        restaurant={restaurant}
+        pageSlug={params.page}
+        pageTitle={pageTitle}
+      />
     );
   } catch {
     notFound();

--- a/components/CustomPageClient.tsx
+++ b/components/CustomPageClient.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Restaurant, WebsiteSection } from "@/lib/types";
+import { SectionRenderer } from "@/components/sections/SectionRenderer";
+import { SiteFooter } from "@/components/SiteFooter";
+import { mapAdminSection, postEditorReady, usePreviewMode } from "@/lib/preview-mode";
+
+/**
+ * Client renderer for a custom website page (/r/<slug>/<page>). Split out from
+ * the server route so it can live-preview drafts inside the foodyadmin website
+ * builder: in preview mode it announces itself to the editor parent and swaps
+ * in the draft sections it receives, exactly like RestaurantLanding does for the
+ * landing page. Outside preview it just renders the published sections.
+ */
+export function CustomPageClient({
+  restaurant,
+  pageSlug,
+  pageTitle,
+}: {
+  restaurant: Restaurant;
+  pageSlug: string;
+  pageTitle: string;
+}) {
+  const slug = restaurant.slug || String(restaurant.id);
+  const previewActive = usePreviewMode();
+  const [overrideSections, setOverrideSections] = useState<WebsiteSection[] | null>(null);
+
+  // Tell the editor parent we're ready so it posts the initial draft state.
+  useEffect(() => {
+    if (previewActive) postEditorReady();
+  }, [previewActive]);
+
+  // Accept draft state from the editor parent (same protocol as the landing).
+  useEffect(() => {
+    function handleMessage(e: MessageEvent) {
+      if (e.data?.type === "foody-draft-state" && e.data.state?.sections) {
+        setOverrideSections(e.data.state.sections.map(mapAdminSection));
+      } else if (e.data?.type === "foody-sections-override" && Array.isArray(e.data.sections)) {
+        setOverrideSections(e.data.sections.map(mapAdminSection));
+      } else if (e.data?.type === "foody-scroll-to-section" && e.data.id != null) {
+        const el = document.querySelector(`[data-section-id="${e.data.id}"]`);
+        if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    }
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
+
+  const baseSections = overrideSections ?? restaurant.websiteSections ?? [];
+  const pageSections = baseSections.filter((s) => s.page === pageSlug);
+
+  return (
+    <div className="min-h-screen bg-[var(--bg-page)] text-[var(--text)]">
+      {/* Nav Bar */}
+      <nav className="sticky top-0 z-40 bg-[var(--surface)]/95 backdrop-blur-md border-b border-[var(--divider)]">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 flex items-center justify-between">
+          <Link href={`/r/${slug}`} className="flex items-center gap-3">
+            {restaurant.logoUrl && (
+              <Image
+                src={restaurant.logoUrl}
+                alt={restaurant.name}
+                width={40}
+                height={40}
+                className="rounded-full object-cover"
+              />
+            )}
+            <span className="font-bold text-lg">{restaurant.name}</span>
+          </Link>
+          <Link
+            href={`/r/${slug}/order`}
+            className="px-5 py-2.5 rounded-full bg-brand text-white font-semibold text-sm hover:opacity-90 transition-opacity"
+          >
+            Order Now
+          </Link>
+        </div>
+      </nav>
+
+      {/* Page Title */}
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
+        <h1 className="text-3xl font-bold">{pageTitle}</h1>
+      </div>
+
+      {/* Sections */}
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        {pageSections.length > 0 ? (
+          <SectionRenderer sections={pageSections} restaurant={restaurant} />
+        ) : (
+          <p className="py-16 text-center text-[var(--text-soft)]">
+            Cette page n&apos;a pas encore de contenu.
+          </p>
+        )}
+      </div>
+
+      {/* Site-wide footer */}
+      <div className="mt-16">
+        <SiteFooter restaurant={restaurant} sectionsOverride={overrideSections ?? undefined} />
+      </div>
+    </div>
+  );
+}

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -30,7 +30,8 @@ import { useResolvedTheme } from "@/lib/themes/useResolvedTheme";
 import { useViewMode } from "@/lib/themes/useViewMode";
 import { currencySymbol } from "@/lib/constants";
 import { checkAvailability } from "@/lib/availability";
-import { MenuItem, MenuResponse, OrderType, Restaurant, ComboMenu, ComboCartSelection } from "@/lib/types";
+import { mapAdminSection, postEditorReady, usePreviewMode } from "@/lib/preview-mode";
+import { MenuItem, MenuResponse, OrderType, Restaurant, ComboMenu, ComboCartSelection, WebsiteSection } from "@/lib/types";
 import { useCartStore } from "@/store/useCartStore";
 import { useTableSession } from "@/store/useTableSession";
 import { createOrder, initSessionPayment, fetchBatchFulfillmentConfig } from "@/services/api";
@@ -140,6 +141,25 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
   // button, no arrow, not tappable. The customer picks pickup/delivery on the
   // checkout page instead (which already exposes an order-type switcher).
   const orderTypeLocked = !!restaurant.websiteConfig?.checkoutConfig?.lock_order_type;
+
+  // In the foodyadmin builder's footer tab, the order page is loaded in an
+  // iframe (?preview=1) to preview the site-wide footer. Accept draft sections
+  // from the editor parent and feed them to <SiteFooter> so footer edits show
+  // live, mirroring RestaurantLanding's preview wiring.
+  const footerPreviewActive = usePreviewMode();
+  const [footerOverride, setFooterOverride] = useState<WebsiteSection[] | null>(null);
+  useEffect(() => {
+    if (footerPreviewActive) postEditorReady();
+  }, [footerPreviewActive]);
+  useEffect(() => {
+    function onDraft(e: MessageEvent) {
+      if (e.data?.type === "foody-draft-state" && e.data.state?.sections) {
+        setFooterOverride(e.data.state.sections.map(mapAdminSection));
+      }
+    }
+    window.addEventListener("message", onDraft);
+    return () => window.removeEventListener("message", onDraft);
+  }, []);
 
   // Check if restaurant is open for current order type. Batch (scheduled bulk
   // order) mode bypasses regular hours for pickup/delivery — orders flow into
@@ -1009,7 +1029,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
       </section>
 
       {/* Site-wide footer at the end of the menu content (above the cart bar). */}
-      <SiteFooter restaurant={restaurant} />
+      <SiteFooter restaurant={restaurant} sectionsOverride={footerOverride ?? undefined} />
 
       {/* Item Modal */}
       <ItemModal

--- a/components/RestaurantLanding.tsx
+++ b/components/RestaurantLanding.tsx
@@ -7,22 +7,8 @@ import { SiteFooter } from "@/components/SiteFooter";
 import { NavigationDrawer } from "@/components/NavigationDrawer";
 import { useRestaurantTheme } from "@/lib/restaurant-theme";
 import { useI18n } from "@/lib/i18n";
-import { postEditorReady, usePreviewMode } from "@/lib/preview-mode";
+import { mapAdminSection, postEditorReady, usePreviewMode } from "@/lib/preview-mode";
 import Link from "next/link";
-
-/** Convert snake_case admin section to camelCase foodyweb section. */
-function mapAdminSection(s: Record<string, any>): WebsiteSection {
-  return {
-    id: s.id ?? s.tmp_id,
-    sectionType: s.section_type ?? s.sectionType,
-    page: s.page || "home",
-    sortOrder: s.sort_order ?? s.sortOrder ?? 0,
-    isVisible: s.is_visible ?? s.isVisible ?? true,
-    layout: s.layout || "",
-    content: s.content || {},
-    settings: s.settings || {},
-  };
-}
 
 type Props = {
   restaurant: Restaurant;

--- a/lib/preview-mode.ts
+++ b/lib/preview-mode.ts
@@ -28,6 +28,25 @@
  */
 
 import { useEffect, useState } from "react";
+import type { WebsiteSection } from "@/lib/types";
+
+/**
+ * Convert a snake_case admin draft section into a camelCase foodyweb
+ * WebsiteSection. Shared by every preview surface (landing, custom pages,
+ * order-page footer) so the admin → web shape mapping lives in one place.
+ */
+export function mapAdminSection(s: Record<string, any>): WebsiteSection {
+  return {
+    id: s.id ?? s.tmp_id,
+    sectionType: s.section_type ?? s.sectionType,
+    page: s.page || "home",
+    sortOrder: s.sort_order ?? s.sortOrder ?? 0,
+    isVisible: s.is_visible ?? s.isVisible ?? true,
+    layout: s.layout || "",
+    content: s.content || {},
+    settings: s.settings || {},
+  };
+}
 
 export type PreviewBounds = {
   id: number | string;


### PR DESCRIPTION
## What
Makes the foodyadmin website builder's **footer** and **custom-page** tabs preview live (they previously showed a placeholder with no iframe).

## Changes
- `lib/preview-mode.ts`: extract shared `mapAdminSection` (admin→web section shape).
- `RestaurantLanding`: use the shared mapper.
- **`CustomPageClient`** (new): preview-aware renderer for `/r/<slug>/<page>` — posts `foody-editor-ready` and applies draft sections + footer override.
- Custom-page route: delegates to `CustomPageClient`; skips 404 under `?preview=1` so unpublished pages still preview.
- `OrderExperience`: listens for `foody-draft-state`, passes `sectionsOverride` to `SiteFooter` (footer previews against the order page).

Pairs with the foodyadmin PR that points the footer/custom-page tabs at these preview routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)