### PR TITLE
Icon-only AI launcher + tappable answer chips

### DIFF
--- a/components/AIOrderAssistant.tsx
+++ b/components/AIOrderAssistant.tsx
@@ -117,6 +117,7 @@ export function AIOrderAssistant({
           content: resp.message,
           items: resp.suggestedItems.length ? resp.suggestedItems : undefined,
           order: resp.order,
+          quickReplies: resp.quickReplies.length ? resp.quickReplies : undefined,
         },
       ]);
     } catch (e: any) {
@@ -173,7 +174,7 @@ export function AIOrderAssistant({
           ref={scrollRef}
           className="flex-1 overflow-y-auto px-3.5 py-4 space-y-3.5 bg-slate-50"
         >
-          {messages.map((m) => (
+          {messages.map((m, idx) => (
             <div key={m.id} className="ai-msg-in">
               {m.role === "user" ? (
                 <div className="flex justify-end">
@@ -215,8 +216,8 @@ export function AIOrderAssistant({
                 </div>
               )}
 
-              {/* Quick replies (greeting) */}
-              {m.quickReplies && !loading && (
+              {/* Quick replies — only on the most recent message */}
+              {m.quickReplies && idx === messages.length - 1 && !loading && (
                 <div className="mt-2.5 ps-9 flex flex-wrap gap-2">
                   {m.quickReplies.map((q) => (
                     <button

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -1356,16 +1356,15 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
       {restaurant.aiAssistantEnabled && !selectedItem && !isComboMode && !orderDetailsOpen && !aiOpen && (
         <button
           onClick={() => setAiOpen(true)}
-          className={`fixed left-6 rtl:left-auto rtl:right-6 z-50 h-14 ps-4 pe-5 rounded-full text-white shadow-lg flex items-center gap-2 hover:scale-105 active:scale-95 transition-transform ${
+          className={`fixed left-6 rtl:left-auto rtl:right-6 z-50 w-14 h-14 rounded-full text-white shadow-lg flex items-center justify-center hover:scale-105 active:scale-95 transition-transform ${
             (totalItems > 0 && cartStyle === "bar-bottom") || isDineInSessionActive
               ? "bottom-24"
               : "bottom-6"
           }`}
-          style={{ background: "var(--brand)" }}
+          style={{ background: "linear-gradient(135deg, var(--brand), var(--brand-dark, var(--brand)))" }}
           aria-label={t("aiAssistant") || "AI ordering assistant"}
         >
-          <span className="text-xl leading-none">✨</span>
-          <span className="text-sm font-bold">{t("aiAssistant") || "Ask AI"}</span>
+          <span className="text-2xl leading-none">✨</span>
         </button>
       )}
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -434,6 +434,8 @@ export interface AIChatResponse {
   message: string;
   suggestedItems: AISuggestedItem[];
   order?: AIPlacedOrder;
+  /** tappable answer choices the assistant offers for its current question */
+  quickReplies: string[];
 }
 
 /**
@@ -467,6 +469,7 @@ export async function sendAIOrderChat(params: {
     message: string;
     suggested_items?: any[];
     order?: any;
+    quick_replies?: string[];
   }>(res);
   return {
     message: data.message ?? "",
@@ -479,6 +482,7 @@ export async function sendAIOrderChat(params: {
       available: s.available !== false,
       reason: s.reason || undefined,
     })),
+    quickReplies: (data.quick_replies ?? []).filter((q): q is string => typeof q === "string"),
     order: data.order
       ? {
           orderId: Number(data.order.order_id),


### PR DESCRIPTION
## Icon-only launcher + tappable answer chips

- **Launcher** is now an icon-only circular FAB (✨) with the brand gradient — the "Ask AI" text label is removed.
- The chat renders the assistant's suggested answer choices (`quick_replies` from the server) as **tappable chips** under its latest question, so the guest can tap "Family", "No restrictions", etc. instead of typing. Chips only show on the most recent message.

Requires the server PR (`suggest_replies` tool / `quick_replies` field).

Validated: `npm run lint`, `npx tsc --noEmit`.

https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8)_