### PR TITLE
Proactive AI assistant nudge (immediate / delayed)

### DIFF
--- a/components/AIOrderAssistant.tsx
+++ b/components/AIOrderAssistant.tsx
@@ -415,3 +415,90 @@ function TypingDots() {
     </div>
   );
 }
+
+/**
+ * AIProactivePrompt is the lightweight "Can I help you order?" nudge shown in
+ * the middle of the screen (immediately or after a delay, per restaurant
+ * settings). Accepting opens the full assistant; dismissing hides it.
+ */
+export function AIProactivePrompt({
+  open,
+  onAccept,
+  onDismiss,
+  restaurantName,
+}: {
+  open: boolean;
+  onAccept: () => void;
+  onDismiss: () => void;
+  restaurantName: string;
+}) {
+  const { t, direction } = useI18n();
+  if (!open) return null;
+
+  const message = (
+    t("aiGreeting") ||
+    "Hi! I'm {name}'s ordering assistant. Want me to help you put together your order?"
+  ).replace("{name}", restaurantName);
+
+  return (
+    <div
+      className="fixed inset-0 z-[68] flex items-center justify-center p-4"
+      dir={direction}
+    >
+      <div
+        className="ai-nudge-fade absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
+        onClick={onDismiss}
+        aria-hidden
+      />
+      <div className="ai-nudge-in relative w-full max-w-[340px] bg-white rounded-[24px] shadow-2xl ring-1 ring-black/5 overflow-hidden">
+        <button
+          onClick={onDismiss}
+          className="absolute top-3 end-3 w-8 h-8 rounded-full text-slate-400 hover:bg-slate-100 flex items-center justify-center transition"
+          aria-label={t("close") || "Close"}
+        >
+          <svg className="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+        <div className="px-6 pt-7 pb-6 text-center">
+          <div className="ai-nudge-grad ai-nudge-bob mx-auto w-16 h-16 rounded-full flex items-center justify-center text-3xl text-white shadow-lg">
+            ✨
+          </div>
+          <p className="mt-4 text-[15px] leading-relaxed text-slate-800 font-medium">
+            {message}
+          </p>
+          <div className="mt-5 flex flex-col gap-2">
+            <button
+              onClick={onAccept}
+              className="ai-nudge-grad w-full py-3 rounded-xl text-white font-bold shadow-md active:scale-[0.98] transition"
+            >
+              {t("aiYesHelp") || "Yes, help me"}
+            </button>
+            <button
+              onClick={onDismiss}
+              className="w-full py-2.5 rounded-xl text-slate-500 font-semibold hover:bg-slate-100 transition"
+            >
+              {t("aiNoThanks") || "No thanks"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <style jsx global>{`
+        @keyframes aiNudgeIn {
+          from { opacity: 0; transform: translateY(14px) scale(0.95); }
+          to { opacity: 1; transform: none; }
+        }
+        @keyframes aiNudgeFade { from { opacity: 0; } to { opacity: 1; } }
+        @keyframes aiNudgeBob {
+          0%, 100% { transform: translateY(0); }
+          50% { transform: translateY(-5px); }
+        }
+        .ai-nudge-grad { background: linear-gradient(135deg, var(--brand), var(--brand-dark, var(--brand))); }
+        .ai-nudge-in { animation: aiNudgeIn 0.32s cubic-bezier(0.2, 0.9, 0.25, 1) both; }
+        .ai-nudge-fade { animation: aiNudgeFade 0.25s ease both; }
+        .ai-nudge-bob { animation: aiNudgeBob 2.6s ease-in-out infinite; }
+      `}</style>
+    </div>
+  );
+}

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -3,7 +3,7 @@
 import { CategoryBanner } from "@/components/themed/CategoryBanner/CategoryBanner";
 import { GroupTabs } from "@/components/CategoryTabs";
 import { CartDrawer } from "@/components/CartDrawer";
-import { AIOrderAssistant } from "@/components/AIOrderAssistant";
+import { AIOrderAssistant, AIProactivePrompt } from "@/components/AIOrderAssistant";
 import { ComboDetailsModal } from "@/components/ComboDetailsModal";
 import { ComboProgressBar } from "@/components/ComboProgressBar";
 import { AnimatePresence, motion } from "framer-motion";
@@ -519,6 +519,49 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
   const [selectedItem, setSelectedItem] = useState<MenuItem | null>(null);
   const [cartOpen, setCartOpen] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
+  const [aiNudgeOpen, setAiNudgeOpen] = useState(false);
+  const aiNudgedRef = useRef(false);
+  const aiOpenRef = useRef(false);
+  useEffect(() => {
+    aiOpenRef.current = aiOpen;
+  }, [aiOpen]);
+
+  // Proactive AI prompt: show a centered "can I help you?" nudge immediately or
+  // after a delay (only if the cart is still empty), per restaurant settings.
+  useEffect(() => {
+    if (!restaurant.aiAssistantEnabled) return;
+    const trigger = restaurant.aiAssistantTrigger ?? "manual";
+    if (trigger === "manual") return;
+
+    const key = `foody-ai-nudged-${restaurantId}`;
+    try {
+      if (sessionStorage.getItem(key)) return;
+    } catch {
+      // sessionStorage unavailable — fall through, the ref still guards re-fires
+    }
+
+    const fire = () => {
+      if (aiNudgedRef.current || aiOpenRef.current) return;
+      if (useCartStore.getState().lines.length > 0) return; // guest already started
+      aiNudgedRef.current = true;
+      try {
+        sessionStorage.setItem(key, "1");
+      } catch {
+        /* ignore */
+      }
+      setAiNudgeOpen(true);
+    };
+
+    const delayMs =
+      trigger === "delay" ? Math.max(0, restaurant.aiAssistantTriggerDelay ?? 45) * 1000 : 600;
+    const id = window.setTimeout(fire, delayMs);
+    return () => window.clearTimeout(id);
+  }, [
+    restaurant.aiAssistantEnabled,
+    restaurant.aiAssistantTrigger,
+    restaurant.aiAssistantTriggerDelay,
+    restaurantId,
+  ]);
   const [searchQuery, setSearchQuery] = useState("");
   const [isScrolling, setIsScrolling] = useState(false);
   const [justAddedId, setJustAddedId] = useState<string | number | null>(null);
@@ -1366,6 +1409,18 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
         >
           <span className="text-2xl leading-none">✨</span>
         </button>
+      )}
+
+      {restaurant.aiAssistantEnabled && (
+        <AIProactivePrompt
+          open={aiNudgeOpen && !aiOpen && !selectedItem && !isComboMode && !orderDetailsOpen}
+          restaurantName={restaurant.name}
+          onAccept={() => {
+            setAiNudgeOpen(false);
+            setAiOpen(true);
+          }}
+          onDismiss={() => setAiNudgeOpen(false)}
+        />
       )}
 
       <AIOrderAssistant

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -427,6 +427,8 @@ export type Restaurant = {
   dineInEnabled: boolean;
   requireDineInPrepayment?: boolean; // If true, dine-in guests must pay before order is sent
   aiAssistantEnabled?: boolean; // If true, show the guest AI ordering assistant
+  aiAssistantTrigger?: "manual" | "immediate" | "delay"; // how the assistant proactively appears
+  aiAssistantTriggerDelay?: number; // seconds before the delayed proactive prompt
   serviceMode?: "counter" | "table"; // counter = day mode (customer picks up), table = night mode (waiter delivers)
   rushMode?: boolean; // When true, restaurant is temporarily paused
   tipsEnabled?: boolean; // When false, skip the tip step for customers

--- a/services/api.ts
+++ b/services/api.ts
@@ -89,6 +89,8 @@ export async function fetchRestaurant(idOrSlug: string): Promise<Restaurant> {
     dineInEnabled: data.restaurant.dine_in_enabled ?? true,
     requireDineInPrepayment: data.restaurant.require_dine_in_prepayment ?? false,
     aiAssistantEnabled: data.restaurant.ai_assistant_enabled ?? false,
+    aiAssistantTrigger: data.restaurant.ai_assistant_trigger || "manual",
+    aiAssistantTriggerDelay: data.restaurant.ai_assistant_trigger_delay ?? 45,
     serviceMode: data.restaurant.service_mode || undefined,
     rushMode: data.restaurant.rush_mode ?? false,
     tipsEnabled: data.restaurant.tips_enabled ?? true,


### PR DESCRIPTION
## Proactive AI assistant nudge

Adds a centered "Can I help you order?" prompt that appears based on the restaurant's trigger setting:
- **immediate** — shortly after the page loads
- **delay** — after the configured number of seconds, **only if the cart is still empty**

Accepting opens the full assistant; dismissing hides it. Shown **once per session** (sessionStorage) and never while the chat or an item modal is open. New `AIProactivePrompt` component with its own animated gradient styling.

Requires the server PR (`ai_assistant_trigger` / `ai_assistant_trigger_delay` on the public payload).

Validated: `npm run lint`, `npx tsc --noEmit`.

https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8)_