### PR TITLE
Send active carte id to the AI assistant

### DIFF
--- a/components/AIOrderAssistant.tsx
+++ b/components/AIOrderAssistant.tsx
@@ -28,6 +28,8 @@ interface Props {
   restaurantName: string;
   orderType: OrderType;
   currency: string;
+  /** active carte id — scopes AI suggestions to the menu the guest is viewing */
+  menuId?: number;
 }
 
 let bubbleSeq = 0;
@@ -40,6 +42,7 @@ export function AIOrderAssistant({
   restaurantName,
   orderType,
   currency,
+  menuId,
 }: Props) {
   const { t, direction, locale } = useI18n();
   const sym = currencySymbol(currency);
@@ -108,6 +111,7 @@ export function AIOrderAssistant({
         history,
         orderType,
         locale,
+        menuId,
       });
       setMessages((prev) => [
         ...prev,

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -1430,6 +1430,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
         restaurantName={restaurant.name}
         orderType={orderType}
         currency={menu.currency}
+        menuId={activeMenuId ?? undefined}
       />
 
       {/* Table Session - Guest Join Modal */}

--- a/services/api.ts
+++ b/services/api.ts
@@ -453,6 +453,8 @@ export async function sendAIOrderChat(params: {
   orderType?: OrderType;
   /** foodyweb UI locale (en | he | fr) — the assistant replies in it */
   locale?: string;
+  /** active carte id — scopes suggestions to the menu the guest is viewing */
+  menuId?: number;
 }): Promise<AIChatResponse> {
   const res = await fetch(
     `${PUBLIC_PREFIX}/ai/order-chat?restaurant_id=${params.restaurantId}`,
@@ -464,6 +466,7 @@ export async function sendAIOrderChat(params: {
         history: params.history,
         order_type: params.orderType,
         locale: params.locale,
+        menu_id: params.menuId,
       }),
     }
   );


### PR DESCRIPTION
## Pass the active carte to the AI assistant

Send the active menu (carte) id with each assistant turn so suggestions are scoped to the carte the guest is currently viewing.

Requires the server PR (`menu_id` scoping).

Validated: `npm run lint`, `npx tsc --noEmit`.

https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8)_