### PR TITLE
Selectable AI suggestions (add to cart) + combo builder

### DIFF
--- a/components/AIOrderAssistant.tsx
+++ b/components/AIOrderAssistant.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { useI18n } from "@/lib/i18n";
 import { currencySymbol } from "@/lib/constants";
+import { lineTotal } from "@/lib/cart";
+import { useCartStore } from "@/store/useCartStore";
 import {
   AIChatMessage,
   AIPlacedOrder,
@@ -30,6 +32,9 @@ interface Props {
   currency: string;
   /** active carte id — scopes AI suggestions to the menu the guest is viewing */
   menuId?: number;
+  /** add a suggested dish to the cart. Returns true if added directly, false
+   *  if it opened a config modal (variants/modifiers/combo). */
+  onPickItem?: (itemId: number) => boolean;
 }
 
 let bubbleSeq = 0;
@@ -43,6 +48,7 @@ export function AIOrderAssistant({
   orderType,
   currency,
   menuId,
+  onPickItem,
 }: Props) {
   const { t, direction, locale } = useI18n();
   const sym = currencySymbol(currency);
@@ -104,6 +110,47 @@ export function AIOrderAssistant({
     setError(null);
     setLoading(true);
 
+    // Snapshot the live cart so the assistant knows what's selected and can
+    // place exactly that. Shapes mirror the orders payload (see checkout).
+    const lines = useCartStore.getState().lines;
+    const cartTotal = useCartStore.getState().total();
+    const cart = lines
+      .filter((l) => !l.comboId)
+      .map((line) => ({
+        menu_item_id: Number(line.item.id),
+        quantity: line.quantity,
+        notes: line.note,
+        selected_variant_id: line.selectedVariantId,
+        modifiers: line.modifiers?.map((m) => ({
+          modifier_id: Number(m.id),
+          applied: true,
+          operator: m.operator,
+        })),
+      }));
+    const combos = lines
+      .filter((l) => l.comboId && l.comboSelections)
+      .map((line) => ({
+        combo_item_id: line.comboId,
+        notes: line.note,
+        selections: line.comboSelections!.map((s) => ({
+          step_id: s.stepId,
+          menu_item_id: s.menuItemId,
+          option_id: s.optionId || undefined,
+          quantity: s.quantity,
+          notes: s.notes,
+        })),
+      }));
+    const cartSummary = lines.length
+      ? lines
+          .map(
+            (l) =>
+              `${l.quantity}× ${l.comboName || l.item.name}${
+                l.selectedVariantName ? ` (${l.selectedVariantName})` : ""
+              } — ${sym}${lineTotal(l).toFixed(2)}`
+          )
+          .join("\n") + `\nTotal: ${sym}${cartTotal.toFixed(2)}`
+      : "";
+
     try {
       const resp = await sendAIOrderChat({
         restaurantId,
@@ -112,6 +159,9 @@ export function AIOrderAssistant({
         orderType,
         locale,
         menuId,
+        cart,
+        combos,
+        cartSummary,
       });
       setMessages((prev) => [
         ...prev,
@@ -208,7 +258,14 @@ export function AIOrderAssistant({
               {m.items && m.items.length > 0 && (
                 <div className="mt-2 ps-9 space-y-2">
                   {m.items.map((it) => (
-                    <ItemCard key={`${m.id}-${it.id}`} item={it} sym={sym} soldOut={t("soldOut") || "Sold out"} />
+                    <ItemCard
+                      key={`${m.id}-${it.id}`}
+                      item={it}
+                      sym={sym}
+                      soldOut={t("soldOut") || "Sold out"}
+                      addLabel={t("aiAdd") || "Add"}
+                      onAdd={onPickItem}
+                    />
                   ))}
                 </div>
               )}
@@ -321,11 +378,25 @@ function ItemCard({
   item,
   sym,
   soldOut,
+  addLabel,
+  onAdd,
 }: {
   item: AISuggestedItem;
   sym: string;
   soldOut: string;
+  addLabel: string;
+  onAdd?: (itemId: number) => boolean;
 }) {
+  const [added, setAdded] = useState(false);
+  const handleAdd = () => {
+    if (!onAdd) return;
+    const direct = onAdd(item.id);
+    if (direct) {
+      setAdded(true);
+      window.setTimeout(() => setAdded(false), 1600);
+    }
+  };
+
   return (
     <div className="flex gap-3 bg-white rounded-2xl shadow-sm ring-1 ring-slate-100 overflow-hidden">
       {item.imageUrl ? (
@@ -340,7 +411,7 @@ function ItemCard({
           🍽️
         </div>
       )}
-      <div className="flex-1 min-w-0 py-2.5 pe-3 flex flex-col justify-center">
+      <div className="flex-1 min-w-0 py-2.5 pe-2 flex flex-col justify-center">
         <div className="font-semibold text-sm text-slate-900 leading-snug line-clamp-1">
           {item.name}
         </div>
@@ -361,6 +432,25 @@ function ItemCard({
           )}
         </div>
       </div>
+      {onAdd && item.available && (
+        <button
+          onClick={handleAdd}
+          aria-label={addLabel}
+          className={`my-auto me-2.5 shrink-0 w-9 h-9 rounded-full flex items-center justify-center shadow-sm active:scale-90 transition ${
+            added ? "bg-emerald-500 text-white" : "ai-grad text-white"
+          }`}
+        >
+          {added ? (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 5v14M5 12h14" />
+            </svg>
+          )}
+        </button>
+      )}
     </div>
   );
 }

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -498,6 +498,31 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
     [isComboMode, comboEligibleIds, handleComboItemTap]
   );
 
+  // AI assistant: add a suggested dish to the cart. Simple items are added
+  // directly; items needing configuration (size/modifiers/combo) open the
+  // normal modal (we close the chat so it isn't hidden behind it). Returns
+  // true when the item was added directly.
+  const handleAiPickItem = useCallback(
+    (itemId: number): boolean => {
+      const item = menu.items.find((i) => String(i.id) === String(itemId));
+      if (!item) return false;
+      const needsConfig =
+        item.itemType === "combo" ||
+        (item.comboSteps?.length ?? 0) > 0 ||
+        (item.modifiers?.length ?? 0) > 0 ||
+        (item.modifierSets?.length ?? 0) > 0 ||
+        (item.optionSets?.length ?? 0) > 0;
+      if (needsConfig) {
+        setAiOpen(false);
+        handleItemClick(item);
+        return false;
+      }
+      addItem(item, 1);
+      return true;
+    },
+    [menu.items, handleItemClick, addItem]
+  );
+
   // Multi-menu support: track which menu is active (null = all menus merged)
   const [activeMenuId, setActiveMenuId] = useState<number | null>(
     menu.menus?.length > 0 ? menu.menus[0].id : null
@@ -1431,6 +1456,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
         orderType={orderType}
         currency={menu.currency}
         menuId={activeMenuId ?? undefined}
+        onPickItem={handleAiPickItem}
       />
 
       {/* Table Session - Guest Join Modal */}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -169,6 +169,7 @@ const translations: Record<Locale, Record<string, string>> = {
     aiOrderNumber: "Order #{id}",
     aiPayNow: "Pay now",
     aiDisclaimer: "AI can make mistakes — please review your order.",
+    aiAdd: "Add",
     goToCheckout: "Go to checkout",
     // Promo banners
     firstOrderDiscount: "First order discount",
@@ -580,6 +581,7 @@ const translations: Record<Locale, Record<string, string>> = {
     aiOrderNumber: "הזמנה מס׳ {id}",
     aiPayNow: "לתשלום",
     aiDisclaimer: "ה-AI עלול לטעות — אנא בדקו את ההזמנה.",
+    aiAdd: "הוסף",
     goToCheckout: "המשך לתשלום",
     // Promo banners
     firstOrderDiscount: "הנחה על הזמנה ראשונה",
@@ -991,6 +993,7 @@ const translations: Record<Locale, Record<string, string>> = {
     aiOrderNumber: "Commande n°{id}",
     aiPayNow: "Payer",
     aiDisclaimer: "L’IA peut se tromper — vérifiez votre commande.",
+    aiAdd: "Ajouter",
     goToCheckout: "Passer à la caisse",
     // Promo banners
     firstOrderDiscount: "Réduction première commande",

--- a/services/api.ts
+++ b/services/api.ts
@@ -455,6 +455,11 @@ export async function sendAIOrderChat(params: {
   locale?: string;
   /** active carte id — scopes suggestions to the menu the guest is viewing */
   menuId?: number;
+  /** the guest's current cart, in the orders payload shape (placed verbatim) */
+  cart?: any[];
+  combos?: any[];
+  /** short human recap of the cart, for the assistant's context */
+  cartSummary?: string;
 }): Promise<AIChatResponse> {
   const res = await fetch(
     `${PUBLIC_PREFIX}/ai/order-chat?restaurant_id=${params.restaurantId}`,
@@ -467,6 +472,9 @@ export async function sendAIOrderChat(params: {
         order_type: params.orderType,
         locale: params.locale,
         menu_id: params.menuId,
+        cart: params.cart,
+        combos: params.combos,
+        cart_summary: params.cartSummary,
       }),
     }
   );


### PR DESCRIPTION
## Selectable AI suggestions + cart-aware assistant

- Suggested dish cards get an **Add (＋)** button. Simple items are added straight to the cart (with a ✓ confirm); items needing options (size/modifiers) or **combos** open the normal modal so they're configured faithfully (the chat closes so the modal isn't hidden behind it).
- Each assistant turn now sends the **live cart** (orders payload shape) and a human cart summary, so the assistant knows exactly what's selected, can upsell/adjust, and places exactly that cart.
- Combo cards route through the existing combo builder (`ComboDetailsModal`).

Requires the server PR (cart on the request + cart-based `place_order`).

Validated: `npm run lint`, `npx tsc --noEmit`.

https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8)_