### PR TITLE
Render future-week carte preview (view-only) on the order page

### DIFF
--- a/app/r/[restaurantId]/order/page.tsx
+++ b/app/r/[restaurantId]/order/page.tsx
@@ -9,8 +9,14 @@ export const dynamic = "force-dynamic";
 
 type PageProps = {
   params: { restaurantId: string };
-  searchParams?: { type?: string };
+  searchParams?: { type?: string; preview_date?: string };
 };
+
+// Accepts only a strict YYYY-MM-DD date for the future-week preview override.
+function parsePreviewDate(value?: string): string | undefined {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return undefined;
+  return value;
+}
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://app.foody-pos.co.il";
 
@@ -58,7 +64,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function OrderPage({ params, searchParams }: PageProps) {
   try {
     const restaurant = await fetchRestaurant(params.restaurantId);
-    const menu = await fetchMenu(String(restaurant.id));
+    const previewDate = parsePreviewDate(searchParams?.preview_date);
+    const menu = await fetchMenu(String(restaurant.id), previewDate);
 
     const pickupEnabled = restaurant.pickupEnabled;
     const deliveryEnabled = restaurant.deliveryEnabled;
@@ -101,6 +108,7 @@ export default async function OrderPage({ params, searchParams }: PageProps) {
         menu={menu}
         restaurant={restaurant}
         initialOrderType={initialOrderType}
+        previewDate={previewDate}
       />
     );
   } catch {

--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -29,9 +29,11 @@ type Props = {
   minimumOrderDelivery?: number;
   /** Current order type — used to enforce minimum order for delivery */
   orderType?: string;
+  /** Future-week preview (view-only): disables checkout so no order is placed. */
+  previewMode?: boolean;
 };
 
-export function CartDrawer({ open, onClose, currency, onCheckout, onSplitPayment, confirmLabel, onConfirmOrder, isSubmitting, successState, minimumOrderDelivery = 0, orderType }: Props) {
+export function CartDrawer({ open, onClose, currency, onCheckout, onSplitPayment, confirmLabel, onConfirmOrder, isSubmitting, successState, minimumOrderDelivery = 0, orderType, previewMode = false }: Props) {
   const { lines, updateQuantity, removeItem, total } = useCartStore();
   const { t, direction } = useI18n();
   const { menuLocale } = useMenuLanguage();
@@ -313,7 +315,7 @@ export function CartDrawer({ open, onClose, currency, onCheckout, onSplitPayment
                       "0 10px 24px -6px color-mix(in srgb, var(--brand) 50%, transparent)",
                   }}
                   onClick={onConfirmOrder || onCheckout}
-                  disabled={displayLines.length === 0 || isSubmitting || isBelowMinimum}
+                  disabled={displayLines.length === 0 || isSubmitting || isBelowMinimum || previewMode}
                 >
                   <span className="flex-shrink-0 w-7 h-7 rounded-full bg-white/22 text-[13px] font-extrabold flex items-center justify-center">
                     {isSubmitting ? (
@@ -326,7 +328,9 @@ export function CartDrawer({ open, onClose, currency, onCheckout, onSplitPayment
                     )}
                   </span>
                   <span className="flex-1 text-start truncate">
-                    {confirmLabel || t("goToCheckout") || "Go to checkout"}
+                    {previewMode
+                      ? t("previewOrderingDisabled") || "Preview — ordering disabled"
+                      : confirmLabel || t("goToCheckout") || "Go to checkout"}
                   </span>
                   <span className="tabular-nums flex-shrink-0">
                     {currencySymbol(currency)}

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -49,9 +49,13 @@ type Props = {
   initialOrderType: OrderType;
   tableId?: string;
   sessionId?: string;
+  /** When set (YYYY-MM-DD), the operator is previewing the carte for a future
+   *  date. View-only: a banner is shown and checkout/order placement is blocked
+   *  so a preview can never turn into a real order. */
+  previewDate?: string;
 };
 
-export function OrderExperience({ menu, restaurant, initialOrderType, tableId, sessionId }: Props) {
+export function OrderExperience({ menu, restaurant, initialOrderType, tableId, sessionId, previewDate }: Props) {
   const router = useRouter();
   const { t, direction, locale } = useI18n();
   // Menu CONTENT resolves against the menu language (original by default,
@@ -67,6 +71,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
   const total = useCartStore((s) => s.total);
 
   const restaurantId = String(restaurant.id);
+  const isDatePreview = !!previewDate;
 
   // Menu layout: starts at the theme's default density, customer can toggle.
   // Toggle is rendered when the active theme allows it (theme.layout.itemDensityToggle).
@@ -797,6 +802,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
   const [cartSuccess, setCartSuccess] = useState(false);
 
   const placeOrderDirect = async () => {
+    if (isDatePreview) return; // view-only preview: never place a real order
     if (isPlacingOrder || lines.length === 0) return;
     setIsPlacingOrder(true);
     try {
@@ -860,6 +866,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
   };
 
   const startCheckout = () => {
+    if (isDatePreview) return; // view-only preview: checkout is disabled
     const checkoutParams = new URLSearchParams({
       restaurantId,
       orderType,
@@ -924,6 +931,19 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
 
   return (
     <main className={`min-h-screen bg-[var(--bg-page)] ${bottomPaddingClass}`} dir={direction}>
+      {/* Future-week preview banner (view-only). Sticky above everything so the
+          operator always knows they're looking at a future date, not live. */}
+      {isDatePreview && previewDate && (
+        <div className="sticky top-0 z-[60] bg-amber-500 text-black px-4 py-2 text-center text-sm font-semibold shadow-md">
+          {(t("previewBannerForDate") || "Preview — menu for {date}").replace(
+            "{date}",
+            formatDateLabel(previewDate, locale)
+          )}
+          <span className="font-normal opacity-80">
+            {" "}· {t("previewOrderingDisabled") || "Ordering is disabled"}
+          </span>
+        </div>
+      )}
       {/* Top Bar - Sticky with transparent/solid transition */}
       <TopBar
         restaurant={restaurant}
@@ -1325,6 +1345,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
         onCheckout={startCheckout}
         minimumOrderDelivery={restaurant.minimumOrderDelivery ?? 0}
         orderType={orderType}
+        previewMode={isDatePreview}
         {...(isDineInNoPrepay ? {
           confirmLabel: t("sendToKitchen") || "Send to kitchen",
           onConfirmOrder: placeOrderDirect,

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -171,6 +171,8 @@ const translations: Record<Locale, Record<string, string>> = {
     aiDisclaimer: "AI can make mistakes — please review your order.",
     aiAdd: "Add",
     goToCheckout: "Go to checkout",
+    previewBannerForDate: "Preview — menu for {date}",
+    previewOrderingDisabled: "Ordering is disabled",
     // Promo banners
     firstOrderDiscount: "First order discount",
     firstOrderDiscountDesc: "Get 10% off your first order",
@@ -583,6 +585,8 @@ const translations: Record<Locale, Record<string, string>> = {
     aiDisclaimer: "ה-AI עלול לטעות — אנא בדקו את ההזמנה.",
     aiAdd: "הוסף",
     goToCheckout: "המשך לתשלום",
+    previewBannerForDate: "תצוגה מקדימה — תפריט ל-{date}",
+    previewOrderingDisabled: "ההזמנה מושבתת",
     // Promo banners
     firstOrderDiscount: "הנחה על הזמנה ראשונה",
     firstOrderDiscountDesc: "קבל 10% הנחה על ההזמנה הראשונה",
@@ -995,6 +999,8 @@ const translations: Record<Locale, Record<string, string>> = {
     aiDisclaimer: "L’IA peut se tromper — vérifiez votre commande.",
     aiAdd: "Ajouter",
     goToCheckout: "Passer à la caisse",
+    previewBannerForDate: "Aperçu — menu du {date}",
+    previewOrderingDisabled: "Commande désactivée",
     // Promo banners
     firstOrderDiscount: "Réduction première commande",
     firstOrderDiscountDesc: "Obtenez 10% de réduction sur votre première commande",

--- a/services/api.ts
+++ b/services/api.ts
@@ -289,8 +289,16 @@ function _mapCategories(rawCats: Array<{ id: number; name?: string; Name?: strin
   return { categories, items };
 }
 
-export async function fetchMenu(restaurantId: string): Promise<MenuResponse> {
-  const res = await fetch(`${PUBLIC_PREFIX}/menu?restaurant_id=${restaurantId}`, {
+export async function fetchMenu(
+  restaurantId: string,
+  previewDate?: string
+): Promise<MenuResponse> {
+  // previewDate (YYYY-MM-DD) lets the restaurant operator preview the carte as it
+  // will look on a future date (weekly rotation preview). It only changes which
+  // items the server returns; the page renders preview as view-only.
+  const params = new URLSearchParams({ restaurant_id: restaurantId });
+  if (previewDate) params.set("preview_date", previewDate);
+  const res = await fetch(`${PUBLIC_PREFIX}/menu?${params.toString()}`, {
     cache: "no-store",
     next: { revalidate: 0 }
   });


### PR DESCRIPTION
## What & why

Lets a restaurant operator preview how the guest order page will look for a future weekly série. Pairs with the server `?preview_date` support and the admin "Preview on web" button.

## Changes

- The order page reads `?preview_date=YYYY-MM-DD` and forwards it to `fetchMenu`.
- Preview is **view-only**: a sticky banner shows the previewed date, and checkout / order placement is disabled (CartDrawer CTA disabled; `startCheckout` and `placeOrderDirect` no-op). A preview can never become a real order — ordering stays locked to the current week.
- i18n added for en / he / fr.

## Validation

`tsc --noEmit` clean; `next lint` reports no errors (only pre-existing `<img>` warnings).

https://claude.ai/code/session_01UaFr8DqR5vhFZXMn6sRKzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaFr8DqR5vhFZXMn6sRKzE)_