### PR TITLE
AI assistant: fully in-chat ordering (no cart/order-page bounce)

### DIFF
--- a/components/AIOrderAssistant.tsx
+++ b/components/AIOrderAssistant.tsx
@@ -3,8 +3,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useI18n } from "@/lib/i18n";
 import { currencySymbol } from "@/lib/constants";
-import { lineTotal } from "@/lib/cart";
-import { useCartStore } from "@/store/useCartStore";
 import {
   AIChatMessage,
   AIPlacedOrder,
@@ -32,9 +30,6 @@ interface Props {
   currency: string;
   /** active carte id — scopes AI suggestions to the menu the guest is viewing */
   menuId?: number;
-  /** add a suggested dish to the cart. Returns true if added directly, false
-   *  if it opened a config modal (variants/modifiers/combo). */
-  onPickItem?: (itemId: number) => boolean;
 }
 
 let bubbleSeq = 0;
@@ -48,7 +43,6 @@ export function AIOrderAssistant({
   orderType,
   currency,
   menuId,
-  onPickItem,
 }: Props) {
   const { t, direction, locale } = useI18n();
   const sym = currencySymbol(currency);
@@ -110,47 +104,6 @@ export function AIOrderAssistant({
     setError(null);
     setLoading(true);
 
-    // Snapshot the live cart so the assistant knows what's selected and can
-    // place exactly that. Shapes mirror the orders payload (see checkout).
-    const lines = useCartStore.getState().lines;
-    const cartTotal = useCartStore.getState().total();
-    const cart = lines
-      .filter((l) => !l.comboId)
-      .map((line) => ({
-        menu_item_id: Number(line.item.id),
-        quantity: line.quantity,
-        notes: line.note,
-        selected_variant_id: line.selectedVariantId,
-        modifiers: line.modifiers?.map((m) => ({
-          modifier_id: Number(m.id),
-          applied: true,
-          operator: m.operator,
-        })),
-      }));
-    const combos = lines
-      .filter((l) => l.comboId && l.comboSelections)
-      .map((line) => ({
-        combo_item_id: line.comboId,
-        notes: line.note,
-        selections: line.comboSelections!.map((s) => ({
-          step_id: s.stepId,
-          menu_item_id: s.menuItemId,
-          option_id: s.optionId || undefined,
-          quantity: s.quantity,
-          notes: s.notes,
-        })),
-      }));
-    const cartSummary = lines.length
-      ? lines
-          .map(
-            (l) =>
-              `${l.quantity}× ${l.comboName || l.item.name}${
-                l.selectedVariantName ? ` (${l.selectedVariantName})` : ""
-              } — ${sym}${lineTotal(l).toFixed(2)}`
-          )
-          .join("\n") + `\nTotal: ${sym}${cartTotal.toFixed(2)}`
-      : "";
-
     try {
       const resp = await sendAIOrderChat({
         restaurantId,
@@ -159,9 +112,6 @@ export function AIOrderAssistant({
         orderType,
         locale,
         menuId,
-        cart,
-        combos,
-        cartSummary,
       });
       setMessages((prev) => [
         ...prev,
@@ -264,7 +214,10 @@ export function AIOrderAssistant({
                       sym={sym}
                       soldOut={t("soldOut") || "Sold out"}
                       addLabel={t("aiAdd") || "Add"}
-                      onAdd={onPickItem}
+                      disabled={loading}
+                      onChoose={(name) =>
+                        send((t("aiWantItem") || "I'd like {name}").replace("{name}", name))
+                      }
                     />
                   ))}
                 </div>
@@ -379,24 +332,16 @@ function ItemCard({
   sym,
   soldOut,
   addLabel,
-  onAdd,
+  disabled,
+  onChoose,
 }: {
   item: AISuggestedItem;
   sym: string;
   soldOut: string;
   addLabel: string;
-  onAdd?: (itemId: number) => boolean;
+  disabled?: boolean;
+  onChoose?: (name: string) => void;
 }) {
-  const [added, setAdded] = useState(false);
-  const handleAdd = () => {
-    if (!onAdd) return;
-    const direct = onAdd(item.id);
-    if (direct) {
-      setAdded(true);
-      window.setTimeout(() => setAdded(false), 1600);
-    }
-  };
-
   return (
     <div className="flex gap-3 bg-white rounded-2xl shadow-sm ring-1 ring-slate-100 overflow-hidden">
       {item.imageUrl ? (
@@ -432,23 +377,16 @@ function ItemCard({
           )}
         </div>
       </div>
-      {onAdd && item.available && (
+      {onChoose && item.available && (
         <button
-          onClick={handleAdd}
+          onClick={() => onChoose(item.name)}
+          disabled={disabled}
           aria-label={addLabel}
-          className={`my-auto me-2.5 shrink-0 w-9 h-9 rounded-full flex items-center justify-center shadow-sm active:scale-90 transition ${
-            added ? "bg-emerald-500 text-white" : "ai-grad text-white"
-          }`}
+          className="my-auto me-2.5 shrink-0 w-9 h-9 rounded-full flex items-center justify-center shadow-sm active:scale-90 transition ai-grad text-white disabled:opacity-50"
         >
-          {added ? (
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
-            </svg>
-          ) : (
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 5v14M5 12h14" />
-            </svg>
-          )}
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 5v14M5 12h14" />
+          </svg>
         </button>
       )}
     </div>

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -498,31 +498,6 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
     [isComboMode, comboEligibleIds, handleComboItemTap]
   );
 
-  // AI assistant: add a suggested dish to the cart. Simple items are added
-  // directly; items needing configuration (size/modifiers/combo) open the
-  // normal modal (we close the chat so it isn't hidden behind it). Returns
-  // true when the item was added directly.
-  const handleAiPickItem = useCallback(
-    (itemId: number): boolean => {
-      const item = menu.items.find((i) => String(i.id) === String(itemId));
-      if (!item) return false;
-      const needsConfig =
-        item.itemType === "combo" ||
-        (item.comboSteps?.length ?? 0) > 0 ||
-        (item.modifiers?.length ?? 0) > 0 ||
-        (item.modifierSets?.length ?? 0) > 0 ||
-        (item.optionSets?.length ?? 0) > 0;
-      if (needsConfig) {
-        setAiOpen(false);
-        handleItemClick(item);
-        return false;
-      }
-      addItem(item, 1);
-      return true;
-    },
-    [menu.items, handleItemClick, addItem]
-  );
-
   // Multi-menu support: track which menu is active (null = all menus merged)
   const [activeMenuId, setActiveMenuId] = useState<number | null>(
     menu.menus?.length > 0 ? menu.menus[0].id : null
@@ -1456,7 +1431,6 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
         orderType={orderType}
         currency={menu.currency}
         menuId={activeMenuId ?? undefined}
-        onPickItem={handleAiPickItem}
       />
 
       {/* Table Session - Guest Join Modal */}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -170,6 +170,7 @@ const translations: Record<Locale, Record<string, string>> = {
     aiPayNow: "Pay now",
     aiDisclaimer: "AI can make mistakes — please review your order.",
     aiAdd: "Add",
+    aiWantItem: "I'd like the {name}",
     goToCheckout: "Go to checkout",
     // Promo banners
     firstOrderDiscount: "First order discount",
@@ -582,6 +583,7 @@ const translations: Record<Locale, Record<string, string>> = {
     aiPayNow: "לתשלום",
     aiDisclaimer: "ה-AI עלול לטעות — אנא בדקו את ההזמנה.",
     aiAdd: "הוסף",
+    aiWantItem: "אשמח להזמין {name}",
     goToCheckout: "המשך לתשלום",
     // Promo banners
     firstOrderDiscount: "הנחה על הזמנה ראשונה",
@@ -994,6 +996,7 @@ const translations: Record<Locale, Record<string, string>> = {
     aiPayNow: "Payer",
     aiDisclaimer: "L’IA peut se tromper — vérifiez votre commande.",
     aiAdd: "Ajouter",
+    aiWantItem: "Je voudrais {name}",
     goToCheckout: "Passer à la caisse",
     // Promo banners
     firstOrderDiscount: "Réduction première commande",

--- a/services/api.ts
+++ b/services/api.ts
@@ -455,11 +455,6 @@ export async function sendAIOrderChat(params: {
   locale?: string;
   /** active carte id — scopes suggestions to the menu the guest is viewing */
   menuId?: number;
-  /** the guest's current cart, in the orders payload shape (placed verbatim) */
-  cart?: any[];
-  combos?: any[];
-  /** short human recap of the cart, for the assistant's context */
-  cartSummary?: string;
 }): Promise<AIChatResponse> {
   const res = await fetch(
     `${PUBLIC_PREFIX}/ai/order-chat?restaurant_id=${params.restaurantId}`,
@@ -472,9 +467,6 @@ export async function sendAIOrderChat(params: {
         order_type: params.orderType,
         locale: params.locale,
         menu_id: params.menuId,
-        cart: params.cart,
-        combos: params.combos,
-        cart_summary: params.cartSummary,
       }),
     }
   );


### PR DESCRIPTION
## Fully in-chat AI ordering (no cart, no order page)

The assistant now drives the whole order conversationally:
- Suggested dish cards' button sends **"I'd like {name}"** into the chat, so the assistant gathers size/extras/combos in conversation instead of opening the order-page modal or touching the cart.
- Dropped the cart snapshot from the chat request; the server builds the order from what the assistant assembled.

Requires the server PR (menu options exposed + conversational `place_order`).

Validated: `npm run lint`, `npx tsc --noEmit`.

https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8)_