### PR TITLE
AI assistant: send visible-item allowlist + hide empty bubble

### DIFF
--- a/components/AIOrderAssistant.tsx
+++ b/components/AIOrderAssistant.tsx
@@ -30,6 +30,8 @@ interface Props {
   currency: string;
   /** active carte id — scopes AI suggestions to the menu the guest is viewing */
   menuId?: number;
+  /** item ids currently visible on the page — hard allowlist for the assistant */
+  visibleItemIds?: number[];
 }
 
 let bubbleSeq = 0;
@@ -43,6 +45,7 @@ export function AIOrderAssistant({
   orderType,
   currency,
   menuId,
+  visibleItemIds,
 }: Props) {
   const { t, direction, locale } = useI18n();
   const sym = currencySymbol(currency);
@@ -112,6 +115,7 @@ export function AIOrderAssistant({
         orderType,
         locale,
         menuId,
+        visibleItemIds,
       });
       setMessages((prev) => [
         ...prev,
@@ -191,9 +195,11 @@ export function AIOrderAssistant({
                   <div className="ai-grad w-7 h-7 rounded-full shrink-0 flex items-center justify-center text-sm text-white shadow-sm">
                     ✨
                   </div>
-                  <div className="max-w-[82%] px-4 py-2.5 rounded-[20px] rounded-bl-md bg-white text-slate-800 text-[14px] leading-relaxed shadow-sm ring-1 ring-slate-100 whitespace-pre-wrap break-words">
-                    {m.content}
-                  </div>
+                  {m.content.trim() && (
+                    <div className="max-w-[82%] px-4 py-2.5 rounded-[20px] rounded-bl-md bg-white text-slate-800 text-[14px] leading-relaxed shadow-sm ring-1 ring-slate-100 whitespace-pre-wrap break-words">
+                      {m.content}
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -515,6 +515,13 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
     return menu.menus.find((m) => m.id === activeMenuId)?.items ?? menu.items;
   }, [menu.menus, menu.items, activeMenuId]);
 
+  // The exact ids the guest can see right now — sent to the AI assistant as a
+  // hard allowlist so it can only ever suggest/order from the active carte.
+  const visibleItemIds = useMemo(
+    () => activeMenuItems.map((i) => Number(i.id)).filter((n) => Number.isFinite(n)),
+    [activeMenuItems]
+  );
+
   const [activeGroup, setActiveGroup] = useState<string>("");
   const [selectedItem, setSelectedItem] = useState<MenuItem | null>(null);
   const [cartOpen, setCartOpen] = useState(false);
@@ -1431,6 +1438,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
         orderType={orderType}
         currency={menu.currency}
         menuId={activeMenuId ?? undefined}
+        visibleItemIds={visibleItemIds}
       />
 
       {/* Table Session - Guest Join Modal */}

--- a/services/api.ts
+++ b/services/api.ts
@@ -455,6 +455,8 @@ export async function sendAIOrderChat(params: {
   locale?: string;
   /** active carte id — scopes suggestions to the menu the guest is viewing */
   menuId?: number;
+  /** exact item ids visible on the page now — hard allowlist for the assistant */
+  visibleItemIds?: number[];
 }): Promise<AIChatResponse> {
   const res = await fetch(
     `${PUBLIC_PREFIX}/ai/order-chat?restaurant_id=${params.restaurantId}`,
@@ -467,6 +469,7 @@ export async function sendAIOrderChat(params: {
         order_type: params.orderType,
         locale: params.locale,
         menu_id: params.menuId,
+        visible_item_ids: params.visibleItemIds,
       }),
     }
   );


### PR DESCRIPTION
## AI assistant: stay on the current menu + no empty bubbles

- **Send `visible_item_ids`** — the ids actually rendered for the active carte — so the server can hard-scope the assistant to the current menu (active menu of the week). Fixes the assistant suggesting dishes that aren't on the guest's carte.
- **Hide the empty assistant bubble** when a turn carries only quick replies / cards and no text.

Requires the server PR (allowlist enforcement + question-text fix).

Validated: `npm run lint`, `npx tsc --noEmit`.

https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BYq6CeMuiyZeh75YkYd8)_