### PR TITLE
Fix category banner cropping on desktop

### DIFF
--- a/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
@@ -10,7 +10,18 @@ export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40 }: Categ
   const veil = Math.min(Math.max(overlay, 0), 100) / 100;
   return (
     <div className="relative my-6 h-40 sm:h-44 lg:h-48 rounded-2xl overflow-hidden">
-      <img src={imageUrl} alt="" className="absolute inset-0 w-full h-full object-cover" />
+      {/* Blurred, zoomed copy fills the box edge-to-edge so the letterbox left by
+          object-contain looks intentional instead of empty — needed on wide
+          desktop where the banner box is far wider than the source graphic. */}
+      <img
+        src={imageUrl}
+        alt=""
+        aria-hidden
+        className="absolute inset-0 w-full h-full object-cover scale-110 blur-xl"
+      />
+      {/* The actual banner: contained so the whole graphic is always visible,
+          regardless of how wide the viewport is. */}
+      <img src={imageUrl} alt="" className="absolute inset-0 w-full h-full object-contain" />
       {veil > 0 && <div className="absolute inset-0" style={{ backgroundColor: `rgba(0,0,0,${veil})` }} />}
       <div className="relative z-10 h-full flex flex-col items-center justify-center px-4 text-center">
         <div className="w-20 sm:w-24 border-t border-white/80 mb-3 sm:mb-4" />


### PR DESCRIPTION
## Problem

The category cover banner looked fine on mobile but was heavily cropped on desktop. It used `object-cover` with a fixed height (`h-40 sm:h-44 lg:h-48`), so on wide viewports the box became far wider than the source graphic and `object-cover` sliced away the top/bottom of the image — only a thin horizontal strip stayed visible.

## Fix

In `components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx`:

- The banner image now uses **`object-contain`**, so the whole graphic is always visible at any viewport width.
- A blurred, zoomed copy of the same image (`object-cover scale-110 blur-xl`) sits behind it to fill the side letterbox so the empty space reads as intentional.
- The dark veil and centered title overlay are unchanged — admin's overlay setting still applies.

Mobile is visually unchanged (the box ratio there already matched the source).

## Notes

`npm run lint` / full `tsc` couldn't run locally (dev deps not installed in the build container) — relying on CI to confirm.

https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML

---
_Generated by [Claude Code](https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML)_