### PR TITLE
Add 'natural' category banner fit mode

### DIFF
--- a/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
@@ -8,12 +8,44 @@ export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "
   // Dark veil darkness is admin-configurable (0-100). The title keeps its own
   // drop-shadow so it stays legible even when the veil is disabled.
   const veil = Math.min(Math.max(overlay, 0), 100) / 100;
+
+  const veilEl = veil > 0 ? <div className="absolute inset-0" style={{ backgroundColor: `rgba(0,0,0,${veil})` }} /> : null;
+  // The title overlay is identical across every fit; it's absolutely positioned
+  // so it centers over the image whether the box has a fixed height or follows
+  // the image's natural aspect ratio.
+  const titleEl = (
+    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center px-4 text-center">
+      <div className="w-20 sm:w-24 border-t border-white/80 mb-3 sm:mb-4" />
+      {/* The responsive base size lives in the --ctb var (1.5rem mobile,
+          1.875rem ≥sm) so the categoryTitle role's size multiplier + the
+          overall scale apply on top of it while keeping responsiveness. */}
+      <h2
+        className="font-display text-white font-bold tracking-[0.15em] drop-shadow-[0_2px_8px_rgba(0,0,0,0.5)] [--ctb:1.5rem] sm:[--ctb:1.875rem]"
+        style={roleTextStyle("categoryTitle", "var(--ctb)", "display", 700)}
+      >
+        {display}
+      </h2>
+      <div className="w-20 sm:w-24 border-t border-white/80 mt-3 sm:mt-4" />
+    </div>
+  );
+
+  // "natural": full-width image at its own aspect ratio — no fixed height, so the
+  // whole graphic shows with no cropping and no letterbox on any screen width.
+  if (fit === "natural") {
+    return (
+      <div className="relative my-6 rounded-2xl overflow-hidden">
+        <img src={imageUrl} alt="" className="block w-full h-auto" />
+        {veilEl}
+        {titleEl}
+      </div>
+    );
+  }
+
+  // "cover" (default) crops to fill a fixed-height box; "contain" shows the whole
+  // image inside that box with a blurred, zoomed copy filling the side letterbox.
   const contain = fit === "contain";
   return (
     <div className="relative my-6 h-40 sm:h-44 lg:h-48 rounded-2xl overflow-hidden">
-      {/* "contain" fit shows the whole graphic (no cropping) on wide desktop;
-          a blurred, zoomed copy fills the resulting side letterbox so it reads
-          as intentional. "cover" (default) crops to fill, the legacy behaviour. */}
       {contain && (
         <img
           src={imageUrl}
@@ -27,20 +59,8 @@ export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "
         alt=""
         className={`absolute inset-0 w-full h-full ${contain ? "object-contain" : "object-cover"}`}
       />
-      {veil > 0 && <div className="absolute inset-0" style={{ backgroundColor: `rgba(0,0,0,${veil})` }} />}
-      <div className="relative z-10 h-full flex flex-col items-center justify-center px-4 text-center">
-        <div className="w-20 sm:w-24 border-t border-white/80 mb-3 sm:mb-4" />
-        {/* The responsive base size lives in the --ctb var (1.5rem mobile,
-            1.875rem ≥sm) so the categoryTitle role's size multiplier + the
-            overall scale apply on top of it while keeping responsiveness. */}
-        <h2
-          className="font-display text-white font-bold tracking-[0.15em] drop-shadow-[0_2px_8px_rgba(0,0,0,0.5)] [--ctb:1.5rem] sm:[--ctb:1.875rem]"
-          style={roleTextStyle("categoryTitle", "var(--ctb)", "display", 700)}
-        >
-          {display}
-        </h2>
-        <div className="w-20 sm:w-24 border-t border-white/80 mt-3 sm:mt-4" />
-      </div>
+      {veilEl}
+      {titleEl}
     </div>
   );
 }

--- a/components/themed/CategoryBanner/CategoryBanner.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.tsx
@@ -12,8 +12,8 @@ export type CategoryBannerProps = {
   capitalize?: boolean;
   /** Darkness (0-100) of the dark veil over the image. Only used by ImageOverlay. */
   overlay?: number;
-  /** How the image fills the banner box: "cover" (crop, default) or "contain" (whole image + blurred fill). Only used by ImageOverlay. */
-  fit?: "cover" | "contain";
+  /** How the image fills the banner box: "cover" (crop, default), "contain" (whole image + blurred fill), or "natural" (full-width at the image's own aspect ratio). Only used by ImageOverlay. */
+  fit?: "cover" | "contain" | "natural";
 };
 
 export function CategoryBanner(props: CategoryBannerProps) {

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -151,7 +151,7 @@ export type PreviewMessage =
       faviconURL?: string;
       categoryBannerStyle?: "image-overlay" | "text-block" | "striped-rule" | "none";
       categoryBannerOverlay?: number;
-      categoryBannerFit?: "cover" | "contain";
+      categoryBannerFit?: "cover" | "contain" | "natural";
       orderPageInfo?: OrderPageInfo | null;
       direction?: Direction;
       typography?: TypographyOverrides | null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -509,8 +509,8 @@ export type WebsiteConfig = {
   categoryBannerStyle?: 'image-overlay' | 'text-block' | 'striped-rule' | 'none';
   /** Darkness (0-100) of the dark veil over image-overlay banners. Defaults to 40; 0 disables it. */
   categoryBannerOverlay?: number;
-  /** How image-overlay banners fill their box: "cover" (crop, default) or "contain" (whole image + blurred fill). */
-  categoryBannerFit?: 'cover' | 'contain';
+  /** How image-overlay banners fill their box: "cover" (crop, default), "contain" (whole image + blurred fill), or "natural" (full-width at the image's own aspect ratio). */
+  categoryBannerFit?: 'cover' | 'contain' | 'natural';
   /** Per-role typography overrides (overall size scale + per-role font/size) for the order/menu page. */
   typography?: import("./themes/typography").TypographyOverrides | null;
   /** Custom pages (beyond home + order). Each renders at /r/<slug>/<page.slug> and appears in the nav. */


### PR DESCRIPTION
## What

Adds a third `categoryBannerFit` mode, **`natural`**, to the order-page category banner:

- **`cover`** (default) — crop to fill a fixed-height box (legacy).
- **`contain`** — whole image centered with a blurred side-fill.
- **`natural`** — full-width image at its **own aspect ratio** (no fixed height, no crop, no blur), so the entire banner graphic shows on every screen width.

## Changes

- `components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx` — renders the three modes; shared veil + title overlay factored out.
- `components/themed/CategoryBanner/CategoryBanner.tsx`, `lib/types.ts`, `lib/themes/types.ts` — widen the `fit` / `categoryBannerFit` union to include `natural`.

Pairs with server (`category_banner_fit`) + admin (3-option control) PRs.

https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML

---
_Generated by [Claude Code](https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML)_