### PR TITLE
web: single Google guest identity across drawer, top bar & order history

### DIFF
--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import { Suspense, useState, useEffect } from "react";
+import { Suspense } from "react";
 import { useI18n } from "@/lib/i18n";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import {
-  sendOTP,
-  verifyOTP,
-  fetchOrderHistory,
-  OrderHistoryItem,
-} from "@/services/api";
+import { useQuery } from "@tanstack/react-query";
+import { fetchMyOrders, GuestOrder } from "@/services/api";
 import { LanguageToggle } from "@/components/LanguageToggle";
-
-type ViewStep = "phone" | "verify" | "orders";
+import { useGuestAccount } from "@/store/useGuestAccount";
+import { GoogleSignIn } from "@/components/GoogleSignIn";
 
 function OrderHistoryLoading() {
   return (
@@ -36,78 +31,20 @@ export default function OrderHistoryPage() {
 
 function OrderHistoryContent() {
   const { t, direction } = useI18n();
-  const [step, setStep] = useState<ViewStep>("phone");
-  const [phone, setPhone] = useState("");
-  const [normalizedPhone, setNormalizedPhone] = useState("");
-  const [otpCode, setOtpCode] = useState("");
-  const [otpError, setOtpError] = useState("");
-  const [countdown, setCountdown] = useState(0);
 
-  // Countdown timer for OTP
-  useEffect(() => {
-    if (countdown > 0) {
-      const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
-      return () => clearTimeout(timer);
-    }
-  }, [countdown]);
+  // Single guest identity — the Google account, shared across the app. The
+  // global page lists orders across every restaurant the guest ordered from.
+  const account = useGuestAccount((s) => s.account);
+  const token = useGuestAccount((s) => s.token);
 
-  // Send OTP mutation
-  const sendOtpMutation = useMutation({
-    mutationFn: async () => {
-      const normalized = phone.startsWith("+")
-        ? phone
-        : `+972${phone.replace(/^0/, "")}`;
-      setNormalizedPhone(normalized);
-      // Cross-restaurant order lookup (no single restaurant): use the global Verify service.
-      return sendOTP(normalized, 0);
-    },
-    onSuccess: () => {
-      setCountdown(60);
-      setStep("verify");
-      setOtpError("");
-    },
-    onError: (error: any) => {
-      setOtpError(error.message || "Failed to send code");
-    },
-  });
-
-  // Verify OTP mutation
-  const verifyOtpMutation = useMutation({
-    mutationFn: async () => {
-      return verifyOTP(normalizedPhone, otpCode, 0);
-    },
-    onSuccess: (data) => {
-      if (data.verified) {
-        setStep("orders");
-        setOtpError("");
-      } else {
-        setOtpError(data.error || t("invalidCode"));
-      }
-    },
-    onError: (error: any) => {
-      setOtpError(error.message || t("invalidCode"));
-    },
-  });
-
-  // Fetch order history query
   const ordersQuery = useQuery({
-    queryKey: ["orderHistory", normalizedPhone],
-    queryFn: () => fetchOrderHistory(normalizedPhone),
-    enabled: step === "orders" && !!normalizedPhone,
+    queryKey: ["myOrders", "all", token],
+    queryFn: () => fetchMyOrders(undefined, 50),
+    enabled: !!token,
     staleTime: 30000,
   });
 
-  const handlePhoneSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    sendOtpMutation.mutate();
-  };
-
-  const handleVerifySubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    verifyOtpMutation.mutate();
-  };
-
-  const orderStatusLabel = (status: string): string => {
+  const orderStatusLabel = (status?: string): string => {
     const labels: Record<string, string> = {
       pending_review: "Pending",
       accepted: "Accepted",
@@ -117,7 +54,7 @@ function OrderHistoryContent() {
       rejected: "Rejected",
       cancelled: "Cancelled",
     };
-    return labels[status] || status;
+    return (status && labels[status]) || status || "";
   };
 
   const orderTypeEmoji: Record<string, string> = {
@@ -141,131 +78,28 @@ function OrderHistoryContent() {
 
       <div className="max-w-lg mx-auto px-4 py-6">
         <AnimatePresence mode="wait">
-          {/* Step 1: Enter Phone */}
-          {step === "phone" && (
+          {/* Signed out → prompt to sign in with Google */}
+          {!account ? (
             <motion.div
-              key="phone"
+              key="signin"
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
               exit={{ opacity: 0, x: -20 }}
             >
               <div className="card p-6 space-y-6">
                 <div className="text-center">
-                  <div className="text-6xl mb-4">📱</div>
+                  <div className="text-6xl mb-4">🧾</div>
                   <h2 className="text-xl font-bold">{t("viewPastOrders") || "View Your Orders"}</h2>
                   <p className="text-sm text-[var(--text-muted)] mt-2">
-                    {t("enterPhoneToViewOrders") ||
-                      "Enter your phone number to view your order history"}
+                    {t("accountSignInHint") ||
+                      "Sign in to find your past orders and check out faster."}
                   </p>
                 </div>
-
-                <form onSubmit={handlePhoneSubmit} className="space-y-4">
-                  <div>
-                    <label className="block text-sm font-medium text-[var(--text-muted)] mb-1">
-                      {t("phone")} *
-                    </label>
-                    <input
-                      type="tel"
-                      value={phone}
-                      onChange={(e) => setPhone(e.target.value)}
-                      required
-                      className="w-full px-4 py-3 border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
-                      placeholder="050-123-4567"
-                      dir="ltr"
-                    />
-                  </div>
-
-                  {otpError && (
-                    <p className="text-sm text-red-500 text-center">{otpError}</p>
-                  )}
-
-                  <button
-                    type="submit"
-                    disabled={sendOtpMutation.isPending || !phone}
-                    className="w-full py-4 rounded-xl bg-brand text-white font-bold shadow-lg shadow-brand/30 hover:bg-brand-dark transition disabled:opacity-50"
-                  >
-                    {sendOtpMutation.isPending ? "..." : t("continue")}
-                  </button>
-                </form>
+                <GoogleSignIn />
               </div>
             </motion.div>
-          )}
-
-          {/* Step 2: Verify OTP */}
-          {step === "verify" && (
-            <motion.div
-              key="verify"
-              initial={{ opacity: 0, x: 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -20 }}
-            >
-              <div className="card p-6 space-y-6">
-                <div>
-                  <h2 className="text-xl font-bold">{t("verifyPhone")}</h2>
-                  <p className="text-sm text-[var(--text-muted)] mt-1">
-                    {t("codeSent")} <span className="font-mono font-bold">{phone}</span>
-                  </p>
-                </div>
-
-                <form onSubmit={handleVerifySubmit} className="space-y-4">
-                  <div>
-                    <label className="block text-sm font-medium text-[var(--text-muted)] mb-1">
-                      {t("enterCode")}
-                    </label>
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      pattern="[0-9]*"
-                      maxLength={6}
-                      value={otpCode}
-                      onChange={(e) => setOtpCode(e.target.value.replace(/\D/g, ""))}
-                      className="w-full px-4 py-4 text-center text-2xl font-mono tracking-[0.5em] border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
-                      placeholder="• • • • • •"
-                      autoFocus
-                      dir="ltr"
-                    />
-                  </div>
-
-                  {otpError && (
-                    <p className="text-sm text-red-500 text-center">{otpError}</p>
-                  )}
-
-                  <button
-                    type="submit"
-                    disabled={otpCode.length !== 6 || verifyOtpMutation.isPending}
-                    className="w-full py-4 rounded-xl bg-brand text-white font-bold shadow-lg shadow-brand/30 hover:bg-brand-dark transition disabled:opacity-50"
-                  >
-                    {verifyOtpMutation.isPending ? "..." : t("verifyCode")}
-                  </button>
-
-                  <div className="flex items-center justify-between text-sm">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setStep("phone");
-                        setOtpCode("");
-                        setOtpError("");
-                      }}
-                      className="text-[var(--text-muted)] hover:text-[var(--text)]"
-                    >
-                      ← {t("back")}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => sendOtpMutation.mutate()}
-                      disabled={countdown > 0 || sendOtpMutation.isPending}
-                      className="text-brand hover:underline disabled:opacity-50 disabled:no-underline"
-                    >
-                      {countdown > 0 ? `${t("resendCode")} (${countdown}s)` : t("resendCode")}
-                    </button>
-                  </div>
-                </form>
-              </div>
-            </motion.div>
-          )}
-
-          {/* Step 3: Order List */}
-          {step === "orders" && (
+          ) : (
+            /* Signed in → order list */
             <motion.div
               key="orders"
               initial={{ opacity: 0, x: 20 }}
@@ -275,7 +109,9 @@ function OrderHistoryContent() {
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                   <h2 className="text-xl font-bold">{t("yourOrders") || "Your Orders"}</h2>
-                  <span className="text-sm text-[var(--text-muted)]">{phone}</span>
+                  <span className="text-sm text-[var(--text-muted)] truncate">
+                    {account.name || account.email}
+                  </span>
                 </div>
 
                 {ordersQuery.isLoading && (
@@ -290,63 +126,67 @@ function OrderHistoryContent() {
                   </div>
                 )}
 
-                {ordersQuery.data && ordersQuery.data.orders.length === 0 && (
+                {ordersQuery.data && ordersQuery.data.length === 0 && (
                   <div className="card p-8 text-center space-y-4">
                     <div className="text-6xl">📭</div>
                     <p className="text-[var(--text-muted)]">
-                      {t("noOrdersFound") || "No orders found for this phone number"}
+                      {t("noOrdersFound") || "No orders found"}
                     </p>
                   </div>
                 )}
 
-                {ordersQuery.data && ordersQuery.data.orders.length > 0 && (
+                {ordersQuery.data && ordersQuery.data.length > 0 && (
                   <div className="space-y-3">
-                    {ordersQuery.data.orders.map((order: OrderHistoryItem) => (
-                      <Link
-                        key={order.id}
-                        href={`/receipt/${order.receipt_token}`}
-                        className="block"
-                      >
+                    {ordersQuery.data.map((order: GuestOrder) => {
+                      const inner = (
                         <div className="card p-4 hover:shadow-lg transition">
                           <div className="flex items-start justify-between">
                             <div>
                               <div className="flex items-center gap-2">
                                 <span className="text-lg">
-                                  {orderTypeEmoji[order.order_type] || "📦"}
+                                  {orderTypeEmoji[order.order_type || ""] || "📦"}
                                 </span>
                                 <span className="font-bold">Order #{order.id}</span>
                               </div>
                               <p className="text-sm text-[var(--text-muted)] mt-1">
                                 {new Date(order.created_at).toLocaleDateString(
                                   direction === "rtl" ? "he-IL" : "en-US",
-                                  {
-                                    dateStyle: "medium",
-                                  }
+                                  { dateStyle: "medium" }
                                 )}
                               </p>
                               <p className="text-sm text-[var(--text-muted)]">
-                                {order.item_count} {order.item_count === 1 ? "item" : "items"}
+                                {order.item_count ?? order.items.length}{" "}
+                                {(order.item_count ?? order.items.length) === 1 ? "item" : "items"}
                               </p>
                             </div>
                             <div className="text-right">
-                              <p className="font-bold text-lg">₪{order.total_amount.toFixed(2)}</p>
-                              <span
-                                className={`inline-block mt-1 px-2 py-0.5 rounded-full text-xs font-medium ${
-                                  order.order_status === "served" || order.order_status === "ready"
-                                    ? "bg-green-100 text-green-800"
-                                    : order.order_status === "cancelled" ||
-                                      order.order_status === "rejected"
-                                    ? "bg-red-100 text-red-800"
-                                    : "bg-blue-100 text-blue-800"
-                                }`}
-                              >
-                                {orderStatusLabel(order.order_status)}
-                              </span>
+                              <p className="font-bold text-lg">₪{order.total.toFixed(2)}</p>
+                              {order.order_status && (
+                                <span
+                                  className={`inline-block mt-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                                    order.order_status === "served" || order.order_status === "ready"
+                                      ? "bg-green-100 text-green-800"
+                                      : order.order_status === "cancelled" ||
+                                        order.order_status === "rejected"
+                                      ? "bg-red-100 text-red-800"
+                                      : "bg-blue-100 text-blue-800"
+                                  }`}
+                                >
+                                  {orderStatusLabel(order.order_status)}
+                                </span>
+                              )}
                             </div>
                           </div>
                         </div>
-                      </Link>
-                    ))}
+                      );
+                      return order.receipt_token ? (
+                        <Link key={order.id} href={`/receipt/${order.receipt_token}`} className="block">
+                          {inner}
+                        </Link>
+                      ) : (
+                        <div key={order.id}>{inner}</div>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/app/r/[restaurantId]/orders/OrderHistoryContent.tsx
+++ b/app/r/[restaurantId]/orders/OrderHistoryContent.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
 import Link from "next/link";
 import Image from "next/image";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { sendOTP, verifyOTP, fetchOrderHistory, OrderHistoryItem } from "@/services/api";
+import { useQuery } from "@tanstack/react-query";
+import { fetchMyOrders, GuestOrder } from "@/services/api";
 import { useI18n } from "@/lib/i18n";
-import { useGuestAuth } from "@/store/useGuestAuth";
+import { useGuestAccount } from "@/store/useGuestAccount";
+import { GoogleSignIn } from "@/components/GoogleSignIn";
 
 type Props = {
   restaurantId: string;
@@ -17,8 +17,6 @@ type Props = {
   restaurantLogoUrl?: string;
 };
 
-type ViewStep = "phone" | "verify" | "orders";
-
 export function OrderHistoryContent({
   restaurantId,
   restaurantSlug,
@@ -26,79 +24,20 @@ export function OrderHistoryContent({
   restaurantLogoUrl,
 }: Props) {
   const router = useRouter();
-  const { direction } = useI18n();
+  const { t, direction } = useI18n();
 
-  // Guest auth
-  const isVerified = useGuestAuth((s) => s.isVerified(restaurantId));
-  const savedPhone = useGuestAuth((s) => s.getPhone(restaurantId));
-  const setVerified = useGuestAuth((s) => s.setVerified);
-
-  // Determine initial step based on auth state
-  const [step, setStep] = useState<ViewStep>(isVerified ? "orders" : "phone");
-  const [phone, setPhone] = useState("");
-  const [normalizedPhone, setNormalizedPhone] = useState(savedPhone || "");
-  const [otpCode, setOtpCode] = useState("");
-  const [otpError, setOtpError] = useState("");
-  const [countdown, setCountdown] = useState(0);
-
-  // If already verified, use saved phone
-  useEffect(() => {
-    if (isVerified && savedPhone) {
-      setNormalizedPhone(savedPhone);
-      setStep("orders");
-    }
-  }, [isVerified, savedPhone]);
-
-  // Countdown timer
-  useEffect(() => {
-    if (countdown > 0) {
-      const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
-      return () => clearTimeout(timer);
-    }
-  }, [countdown]);
-
-  const sendOtpMutation = useMutation({
-    mutationFn: async () => {
-      const normalized = phone.startsWith("+")
-        ? phone
-        : `+972${phone.replace(/^0/, "")}`;
-      setNormalizedPhone(normalized);
-      return sendOTP(normalized, Number(restaurantId));
-    },
-    onSuccess: () => {
-      setCountdown(60);
-      setStep("verify");
-      setOtpError("");
-    },
-    onError: (error: Error) => {
-      setOtpError(error.message || "Failed to send code");
-    },
-  });
-
-  const verifyOtpMutation = useMutation({
-    mutationFn: () => verifyOTP(normalizedPhone, otpCode, Number(restaurantId)),
-    onSuccess: (data) => {
-      if (data.verified) {
-        setVerified(restaurantId, normalizedPhone);
-        setStep("orders");
-        setOtpError("");
-      } else {
-        setOtpError("Invalid code. Please try again.");
-      }
-    },
-    onError: (error: Error) => {
-      setOtpError(error.message || "Invalid code");
-    },
-  });
+  // Single guest identity — the Google account, shared across the app.
+  const account = useGuestAccount((s) => s.account);
+  const token = useGuestAccount((s) => s.token);
 
   const ordersQuery = useQuery({
-    queryKey: ["orderHistory", normalizedPhone, restaurantId],
-    queryFn: () => fetchOrderHistory(normalizedPhone, restaurantId),
-    enabled: step === "orders" && !!normalizedPhone,
+    queryKey: ["myOrders", restaurantId, token],
+    queryFn: () => fetchMyOrders(restaurantId, 50),
+    enabled: !!token,
     staleTime: 30000,
   });
 
-  const orderStatusLabel = (status: string): string => {
+  const orderStatusLabel = (status?: string): string => {
     const labels: Record<string, string> = {
       pending_review: "Pending",
       accepted: "Accepted",
@@ -108,7 +47,7 @@ export function OrderHistoryContent({
       rejected: "Rejected",
       cancelled: "Cancelled",
     };
-    return labels[status] || status;
+    return (status && labels[status]) || status || "";
   };
 
   const orderTypeEmoji: Record<string, string> = {
@@ -145,127 +84,36 @@ export function OrderHistoryContent({
               className="w-8 h-8 rounded-full object-cover"
             />
           )}
-          <h1 className="text-lg font-bold text-[var(--text)] truncate">My Orders</h1>
+          <h1 className="text-lg font-bold text-[var(--text)] truncate">
+            {t("accountMyOrders") || "My Orders"}
+          </h1>
         </div>
       </header>
 
       <div className="max-w-lg mx-auto px-4 py-6">
         <AnimatePresence mode="wait">
-          {/* Step 1: Enter Phone */}
-          {step === "phone" && (
+          {/* Signed out → prompt to sign in with Google */}
+          {!account ? (
             <motion.div
-              key="phone"
+              key="signin"
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
               exit={{ opacity: 0, x: -20 }}
             >
               <div className="card p-6 space-y-6">
                 <div className="text-center">
-                  <div className="text-6xl mb-4">📱</div>
-                  <h2 className="text-xl font-bold">View Your Orders</h2>
+                  <div className="text-6xl mb-4">🧾</div>
+                  <h2 className="text-xl font-bold">{t("accountMyOrders") || "View Your Orders"}</h2>
                   <p className="text-sm text-[var(--text-muted)] mt-2">
-                    Enter your phone number to view your order history at {restaurantName}
+                    {t("accountSignInHint") ||
+                      "Sign in to find your past orders and check out faster."}
                   </p>
                 </div>
-                <form
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    sendOtpMutation.mutate();
-                  }}
-                  className="space-y-4"
-                >
-                  <input
-                    type="tel"
-                    value={phone}
-                    onChange={(e) => setPhone(e.target.value)}
-                    required
-                    className="w-full px-4 py-3 border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
-                    placeholder="050-123-4567"
-                    dir="ltr"
-                  />
-                  {otpError && <p className="text-sm text-red-500 text-center">{otpError}</p>}
-                  <button
-                    type="submit"
-                    disabled={sendOtpMutation.isPending || !phone}
-                    className="w-full py-4 rounded-xl bg-brand text-white font-bold shadow-lg shadow-brand/30 hover:bg-brand-dark transition disabled:opacity-50"
-                  >
-                    {sendOtpMutation.isPending ? "Sending..." : "Send Code"}
-                  </button>
-                </form>
+                <GoogleSignIn />
               </div>
             </motion.div>
-          )}
-
-          {/* Step 2: Verify OTP */}
-          {step === "verify" && (
-            <motion.div
-              key="verify"
-              initial={{ opacity: 0, x: 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -20 }}
-            >
-              <div className="card p-6 space-y-6">
-                <div>
-                  <h2 className="text-xl font-bold">Verify Phone</h2>
-                  <p className="text-sm text-[var(--text-muted)] mt-1">
-                    Enter the code sent to <span className="font-mono font-bold">{phone}</span>
-                  </p>
-                </div>
-                <form
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    verifyOtpMutation.mutate();
-                  }}
-                  className="space-y-4"
-                >
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    pattern="[0-9]*"
-                    maxLength={6}
-                    value={otpCode}
-                    onChange={(e) => setOtpCode(e.target.value.replace(/\D/g, ""))}
-                    className="w-full px-4 py-4 text-center text-2xl font-mono tracking-[0.5em] border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
-                    placeholder="• • • • • •"
-                    autoFocus
-                    dir="ltr"
-                  />
-                  {otpError && <p className="text-sm text-red-500 text-center">{otpError}</p>}
-                  <button
-                    type="submit"
-                    disabled={otpCode.length !== 6 || verifyOtpMutation.isPending}
-                    className="w-full py-4 rounded-xl bg-brand text-white font-bold shadow-lg shadow-brand/30 hover:bg-brand-dark transition disabled:opacity-50"
-                  >
-                    {verifyOtpMutation.isPending ? "Verifying..." : "Verify"}
-                  </button>
-                  <div className="flex items-center justify-between text-sm">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setStep("phone");
-                        setOtpCode("");
-                        setOtpError("");
-                      }}
-                      className="text-[var(--text-muted)] hover:text-[var(--text)]"
-                    >
-                      Change number
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => sendOtpMutation.mutate()}
-                      disabled={countdown > 0 || sendOtpMutation.isPending}
-                      className="text-brand hover:underline disabled:opacity-50 disabled:no-underline"
-                    >
-                      {countdown > 0 ? `Resend (${countdown}s)` : "Resend"}
-                    </button>
-                  </div>
-                </form>
-              </div>
-            </motion.div>
-          )}
-
-          {/* Step 3: Order List */}
-          {step === "orders" && (
+          ) : (
+            /* Signed in → order list */
             <motion.div
               key="orders"
               initial={{ opacity: 0, x: 20 }}
@@ -285,29 +133,28 @@ export function OrderHistoryContent({
                   </div>
                 )}
 
-                {ordersQuery.data && ordersQuery.data.orders.length === 0 && (
+                {ordersQuery.data && ordersQuery.data.length === 0 && (
                   <div className="card p-8 text-center space-y-4">
                     <div className="text-6xl">📭</div>
                     <p className="text-[var(--text-muted)]">
-                      No orders found at {restaurantName}
+                      {(t("reorderEmpty") || "No orders found at {name}").replace(
+                        "{name}",
+                        restaurantName
+                      )}
                     </p>
                   </div>
                 )}
 
-                {ordersQuery.data && ordersQuery.data.orders.length > 0 && (
+                {ordersQuery.data && ordersQuery.data.length > 0 && (
                   <div className="space-y-3">
-                    {ordersQuery.data.orders.map((order: OrderHistoryItem) => (
-                      <Link
-                        key={order.id}
-                        href={`/receipt/${order.receipt_token}`}
-                        className="block"
-                      >
+                    {ordersQuery.data.map((order: GuestOrder) => {
+                      const inner = (
                         <div className="card p-4 hover:shadow-lg transition">
                           <div className="flex items-start justify-between">
                             <div>
                               <div className="flex items-center gap-2">
                                 <span className="text-lg">
-                                  {orderTypeEmoji[order.order_type] || "📦"}
+                                  {orderTypeEmoji[order.order_type || ""] || "📦"}
                                 </span>
                                 <span className="font-bold">Order #{order.id}</span>
                               </div>
@@ -318,27 +165,38 @@ export function OrderHistoryContent({
                                 )}
                               </p>
                               <p className="text-sm text-[var(--text-muted)]">
-                                {order.item_count} {order.item_count === 1 ? "item" : "items"}
+                                {order.item_count ?? order.items.length}{" "}
+                                {(order.item_count ?? order.items.length) === 1 ? "item" : "items"}
                               </p>
                             </div>
                             <div className="text-right">
-                              <p className="font-bold text-lg">₪{order.total_amount.toFixed(2)}</p>
-                              <span
-                                className={`inline-block mt-1 px-2 py-0.5 rounded-full text-xs font-medium ${
-                                  order.order_status === "served" || order.order_status === "ready"
-                                    ? "bg-green-100 text-green-800"
-                                    : order.order_status === "cancelled" || order.order_status === "rejected"
-                                    ? "bg-red-100 text-red-800"
-                                    : "bg-blue-100 text-blue-800"
-                                }`}
-                              >
-                                {orderStatusLabel(order.order_status)}
-                              </span>
+                              <p className="font-bold text-lg">₪{order.total.toFixed(2)}</p>
+                              {order.order_status && (
+                                <span
+                                  className={`inline-block mt-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                                    order.order_status === "served" || order.order_status === "ready"
+                                      ? "bg-green-100 text-green-800"
+                                      : order.order_status === "cancelled" ||
+                                        order.order_status === "rejected"
+                                      ? "bg-red-100 text-red-800"
+                                      : "bg-blue-100 text-blue-800"
+                                  }`}
+                                >
+                                  {orderStatusLabel(order.order_status)}
+                                </span>
+                              )}
                             </div>
                           </div>
                         </div>
-                      </Link>
-                    ))}
+                      );
+                      return order.receipt_token ? (
+                        <Link key={order.id} href={`/receipt/${order.receipt_token}`} className="block">
+                          {inner}
+                        </Link>
+                      ) : (
+                        <div key={order.id}>{inner}</div>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/components/NavigationDrawer.tsx
+++ b/components/NavigationDrawer.tsx
@@ -4,101 +4,47 @@ import { useState, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useMutation } from "@tanstack/react-query";
+import { usePathname, useRouter } from "next/navigation";
 import { Restaurant } from "@/lib/types";
 import { useI18n } from "@/lib/i18n";
-import { useGuestAuth } from "@/store/useGuestAuth";
+import { useGuestAccount } from "@/store/useGuestAccount";
 import { LanguageToggle } from "@/components/LanguageToggle";
-import { sendOTP, verifyOTP } from "@/services/api";
+import { GoogleSignIn } from "@/components/GoogleSignIn";
+import { OrderHistorySheet } from "@/components/OrderHistorySheet";
+import type { GuestOrder } from "@/services/api";
 
 type Props = {
   open: boolean;
   onClose: () => void;
   restaurant: Restaurant;
+  /** Currency for the order-history sheet. Defaults to ILS. */
+  currency?: string;
+  /** Reorder handler — adds a past order to the cart. When omitted (e.g. on the
+   *  marketing landing where there's no cart), reorder routes to the menu. */
+  onReorder?: (order: GuestOrder) => void;
 };
 
-type DrawerView = "nav" | "signin";
-
-export function NavigationDrawer({ open, onClose, restaurant }: Props) {
-  const { direction } = useI18n();
+export function NavigationDrawer({ open, onClose, restaurant, currency, onReorder }: Props) {
+  const { t, direction } = useI18n();
   const pathname = usePathname();
+  const router = useRouter();
   const slug = restaurant.slug || String(restaurant.id);
   const restaurantId = String(restaurant.id);
 
-  const isVerified = useGuestAuth((s) => s.isVerified(restaurantId));
-  const phone = useGuestAuth((s) => s.getPhone(restaurantId));
-  const setVerified = useGuestAuth((s) => s.setVerified);
-  const clearSession = useGuestAuth((s) => s.clearSession);
+  // Single guest identity — the Google account (shared with the top-bar menu,
+  // checkout prefill and the AI reorder assistant).
+  const account = useGuestAccount((s) => s.account);
+  const signOut = useGuestAccount((s) => s.signOut);
 
-  const [view, setView] = useState<DrawerView>("nav");
+  const [historyOpen, setHistoryOpen] = useState(false);
 
-  // Sign-in form state
-  const [phoneInput, setPhoneInput] = useState("");
-  const [otpCode, setOtpCode] = useState("");
-  const [normalizedPhone, setNormalizedPhone] = useState("");
-  const [otpError, setOtpError] = useState("");
-  const [otpStep, setOtpStep] = useState<"phone" | "code">("phone");
-  const [countdown, setCountdown] = useState(0);
-
-  // Reset state when drawer opens/closes
+  // Close the order-history sheet whenever the drawer itself closes.
   useEffect(() => {
-    if (!open) {
-      setTimeout(() => {
-        setView("nav");
-        setPhoneInput("");
-        setOtpCode("");
-        setOtpError("");
-        setOtpStep("phone");
-      }, 300);
-    }
+    if (!open) setHistoryOpen(false);
   }, [open]);
-
-  // Countdown timer
-  useEffect(() => {
-    if (countdown > 0) {
-      const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
-      return () => clearTimeout(timer);
-    }
-  }, [countdown]);
 
   const isRTL = direction === "rtl";
   const slideFrom = isRTL ? "100%" : "-100%";
-
-  // OTP mutations
-  const sendOtpMutation = useMutation({
-    mutationFn: async () => {
-      const normalized = phoneInput.startsWith("+")
-        ? phoneInput
-        : `+972${phoneInput.replace(/^0/, "")}`;
-      setNormalizedPhone(normalized);
-      return sendOTP(normalized, Number(restaurantId));
-    },
-    onSuccess: () => {
-      setCountdown(60);
-      setOtpStep("code");
-      setOtpError("");
-    },
-    onError: (error: Error) => {
-      setOtpError(error.message || "Failed to send code");
-    },
-  });
-
-  const verifyOtpMutation = useMutation({
-    mutationFn: () => verifyOTP(normalizedPhone, otpCode, Number(restaurantId)),
-    onSuccess: (data) => {
-      if (data.verified) {
-        setVerified(restaurantId, normalizedPhone);
-        setView("nav");
-        setOtpError("");
-      } else {
-        setOtpError("Invalid code. Please try again.");
-      }
-    },
-    onError: (error: Error) => {
-      setOtpError(error.message || "Invalid code");
-    },
-  });
 
   // When the restaurant has opted out of the marketing landing page, the
   // /r/<slug> route redirects to /order anyway — so listing "Home" and "Menu"
@@ -151,269 +97,160 @@ export function NavigationDrawer({ open, onClose, restaurant }: Props) {
     })),
   ];
 
-  const navLinks = [
-    ...pageNavLinks,
-    {
-      label: "My Orders",
-      href: `/r/${slug}/orders`,
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
-        </svg>
-      ),
-    },
-  ];
+  const ordersIcon = (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+    </svg>
+  );
+
+  const handleReorder = (order: GuestOrder) => {
+    setHistoryOpen(false);
+    onClose();
+    if (onReorder) {
+      onReorder(order);
+    } else {
+      // No cart in this context (e.g. landing) — take the guest to the menu.
+      router.push(`/r/${slug}/order`);
+    }
+  };
 
   return (
-    <AnimatePresence>
-      {open && (
-        <>
-          {/* Backdrop */}
-          <motion.div
-            key="nav-backdrop"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm"
-            onClick={onClose}
-          />
+    <>
+      <AnimatePresence>
+        {open && (
+          <>
+            {/* Backdrop */}
+            <motion.div
+              key="nav-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm"
+              onClick={onClose}
+            />
 
-          {/* Drawer panel */}
-          <motion.div
-            key="nav-drawer"
-            initial={{ x: slideFrom }}
-            animate={{ x: 0 }}
-            exit={{ x: slideFrom }}
-            transition={{ type: "spring", damping: 30, stiffness: 300 }}
-            className={`fixed top-0 ${isRTL ? "right-0" : "left-0"} bottom-0 z-[60] w-[80vw] max-w-[320px] bg-[var(--surface)] flex flex-col shadow-2xl`}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <AnimatePresence mode="wait">
-              {view === "nav" ? (
-                <motion.div
-                  key="nav-view"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  className="flex flex-col h-full"
-                >
-                  {/* Header */}
-                  <div className="flex items-center gap-3 px-5 pt-6 pb-4">
-                    {restaurant.logoUrl ? (
-                      <Image
-                        src={restaurant.logoUrl}
-                        alt={restaurant.name}
-                        width={44}
-                        height={44}
-                        className="w-11 h-11 rounded-full object-cover"
-                      />
-                    ) : (
-                      <div className="w-11 h-11 rounded-full bg-brand flex items-center justify-center text-white font-bold text-lg">
-                        {restaurant.name.charAt(0)}
-                      </div>
-                    )}
-                    <div className="flex-1 min-w-0">
-                      <h2 className="font-bold text-[var(--text)] truncate">{restaurant.name}</h2>
-                      {isVerified && phone && (
-                        <p className="text-xs text-[var(--text-muted)] truncate">{phone}</p>
-                      )}
+            {/* Drawer panel */}
+            <motion.div
+              key="nav-drawer"
+              initial={{ x: slideFrom }}
+              animate={{ x: 0 }}
+              exit={{ x: slideFrom }}
+              transition={{ type: "spring", damping: 30, stiffness: 300 }}
+              className={`fixed top-0 ${isRTL ? "right-0" : "left-0"} bottom-0 z-[60] w-[80vw] max-w-[320px] bg-[var(--surface)] flex flex-col shadow-2xl`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex flex-col h-full">
+                {/* Header */}
+                <div className="flex items-center gap-3 px-5 pt-6 pb-4">
+                  {restaurant.logoUrl ? (
+                    <Image
+                      src={restaurant.logoUrl}
+                      alt={restaurant.name}
+                      width={44}
+                      height={44}
+                      className="w-11 h-11 rounded-full object-cover"
+                    />
+                  ) : (
+                    <div className="w-11 h-11 rounded-full bg-brand flex items-center justify-center text-white font-bold text-lg">
+                      {restaurant.name.charAt(0)}
                     </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <h2 className="font-bold text-[var(--text)] truncate">{restaurant.name}</h2>
+                    {account && (
+                      <p className="text-xs text-[var(--text-muted)] truncate">
+                        {account.name || account.email}
+                      </p>
+                    )}
+                  </div>
+                  <button
+                    onClick={onClose}
+                    className="w-8 h-8 flex items-center justify-center rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-subtle)] transition"
+                    aria-label="Close"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+
+                <div className="h-px bg-[var(--divider)] mx-5" />
+
+                {/* Auth section — single Google identity, shared with the top bar */}
+                <div className="px-5 py-4">
+                  {account ? (
                     <button
-                      onClick={onClose}
-                      className="w-8 h-8 flex items-center justify-center rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-subtle)] transition"
-                      aria-label="Close"
+                      onClick={() => signOut()}
+                      className="flex items-center gap-3 w-full text-sm text-[var(--text-muted)] hover:text-red-500 transition"
                     >
                       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
                       </svg>
+                      {t("accountSignOut") || "Sign out"}
                     </button>
-                  </div>
-
-                  <div className="h-px bg-[var(--divider)] mx-5" />
-
-                  {/* Auth section */}
-                  <div className="px-5 py-4">
-                    {isVerified ? (
-                      <button
-                        onClick={() => {
-                          clearSession(restaurantId);
-                        }}
-                        className="flex items-center gap-3 w-full text-sm text-[var(--text-muted)] hover:text-red-500 transition"
-                      >
-                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-                        </svg>
-                        Sign Out
-                      </button>
-                    ) : (
-                      <button
-                        onClick={() => setView("signin")}
-                        className="flex items-center gap-3 w-full px-4 py-3 rounded-xl bg-brand text-white font-semibold text-sm hover:opacity-90 transition"
-                      >
-                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                        </svg>
-                        Sign In
-                      </button>
-                    )}
-                  </div>
-
-                  <div className="h-px bg-[var(--divider)] mx-5" />
-
-                  {/* Nav links */}
-                  <nav className="flex-1 px-3 py-3">
-                    {navLinks.map((link) => {
-                      const isActive = pathname === link.href;
-                      return (
-                        <Link
-                          key={link.href}
-                          href={link.href}
-                          onClick={onClose}
-                          className={`flex items-center gap-3 px-3 py-3 rounded-xl text-sm font-medium transition ${
-                            isActive
-                              ? "bg-brand/10 text-brand"
-                              : "text-[var(--text)] hover:bg-[var(--surface-subtle)]"
-                          }`}
-                        >
-                          {link.icon}
-                          {link.label}
-                        </Link>
-                      );
-                    })}
-                  </nav>
-
-                  {/* Language toggle at bottom */}
-                  <div className="px-5 py-4 border-t border-[var(--divider)]">
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm text-[var(--text-muted)]">Language</span>
-                      <LanguageToggle />
+                  ) : (
+                    <div className="space-y-3">
+                      <p className="text-xs text-[var(--text-muted)] leading-relaxed">
+                        {t("accountSignInHint") || "Sign in to find your past orders and check out faster."}
+                      </p>
+                      <GoogleSignIn />
                     </div>
-                  </div>
-                </motion.div>
-              ) : (
-                /* Sign-in view */
-                <motion.div
-                  key="signin-view"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  className="flex flex-col h-full"
-                >
-                  {/* Header */}
-                  <div className="flex items-center gap-3 px-5 pt-6 pb-4">
-                    <button
-                      onClick={() => {
-                        setView("nav");
-                        setOtpError("");
-                        setOtpStep("phone");
-                        setOtpCode("");
-                      }}
-                      className="w-8 h-8 flex items-center justify-center rounded-full text-[var(--text-muted)] hover:bg-[var(--surface-subtle)] transition"
-                      aria-label="Back"
-                    >
-                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={isRTL ? "M9 5l7 7-7 7" : "M15 19l-7-7 7-7"} />
-                      </svg>
-                    </button>
-                    <h2 className="font-bold text-lg text-[var(--text)]">Sign In</h2>
-                  </div>
+                  )}
+                </div>
 
-                  <div className="px-5 flex-1">
-                    {otpStep === "phone" ? (
-                      <form
-                        onSubmit={(e) => {
-                          e.preventDefault();
-                          sendOtpMutation.mutate();
-                        }}
-                        className="space-y-4"
+                <div className="h-px bg-[var(--divider)] mx-5" />
+
+                {/* Nav links */}
+                <nav className="flex-1 px-3 py-3">
+                  {pageNavLinks.map((link) => {
+                    const isActive = pathname === link.href;
+                    return (
+                      <Link
+                        key={link.href}
+                        href={link.href}
+                        onClick={onClose}
+                        className={`flex items-center gap-3 px-3 py-3 rounded-xl text-sm font-medium transition ${
+                          isActive
+                            ? "bg-brand/10 text-brand"
+                            : "text-[var(--text)] hover:bg-[var(--surface-subtle)]"
+                        }`}
                       >
-                        <p className="text-sm text-[var(--text-muted)]">
-                          Enter your phone number to sign in and access your order history.
-                        </p>
-                        <input
-                          type="tel"
-                          value={phoneInput}
-                          onChange={(e) => setPhoneInput(e.target.value)}
-                          required
-                          className="w-full px-4 py-3 border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
-                          placeholder="050-123-4567"
-                          dir="ltr"
-                        />
-                        {otpError && (
-                          <p className="text-sm text-red-500">{otpError}</p>
-                        )}
-                        <button
-                          type="submit"
-                          disabled={sendOtpMutation.isPending || !phoneInput}
-                          className="w-full py-3 rounded-xl bg-brand text-white font-bold hover:opacity-90 transition disabled:opacity-50"
-                        >
-                          {sendOtpMutation.isPending ? "Sending..." : "Send Code"}
-                        </button>
-                      </form>
-                    ) : (
-                      <form
-                        onSubmit={(e) => {
-                          e.preventDefault();
-                          verifyOtpMutation.mutate();
-                        }}
-                        className="space-y-4"
-                      >
-                        <p className="text-sm text-[var(--text-muted)]">
-                          Enter the 6-digit code sent to{" "}
-                          <span className="font-mono font-bold">{phoneInput}</span>
-                        </p>
-                        <input
-                          type="text"
-                          inputMode="numeric"
-                          pattern="[0-9]*"
-                          maxLength={6}
-                          value={otpCode}
-                          onChange={(e) => setOtpCode(e.target.value.replace(/\D/g, ""))}
-                          className="w-full px-4 py-4 text-center text-2xl font-mono tracking-[0.5em] border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
-                          placeholder="• • • • • •"
-                          autoFocus
-                          dir="ltr"
-                        />
-                        {otpError && (
-                          <p className="text-sm text-red-500">{otpError}</p>
-                        )}
-                        <button
-                          type="submit"
-                          disabled={otpCode.length !== 6 || verifyOtpMutation.isPending}
-                          className="w-full py-3 rounded-xl bg-brand text-white font-bold hover:opacity-90 transition disabled:opacity-50"
-                        >
-                          {verifyOtpMutation.isPending ? "Verifying..." : "Verify"}
-                        </button>
-                        <div className="flex items-center justify-between text-sm">
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setOtpStep("phone");
-                              setOtpCode("");
-                              setOtpError("");
-                            }}
-                            className="text-[var(--text-muted)] hover:text-[var(--text)]"
-                          >
-                            Change number
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => sendOtpMutation.mutate()}
-                            disabled={countdown > 0 || sendOtpMutation.isPending}
-                            className="text-brand hover:underline disabled:opacity-50 disabled:no-underline"
-                          >
-                            {countdown > 0 ? `Resend (${countdown}s)` : "Resend"}
-                          </button>
-                        </div>
-                      </form>
-                    )}
+                        {link.icon}
+                        {link.label}
+                      </Link>
+                    );
+                  })}
+
+                  {/* My Orders — opens the same history sheet as the top bar */}
+                  <button
+                    onClick={() => setHistoryOpen(true)}
+                    className="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-medium text-[var(--text)] hover:bg-[var(--surface-subtle)] transition text-start"
+                  >
+                    {ordersIcon}
+                    {t("accountMyOrders") || "My Orders"}
+                  </button>
+                </nav>
+
+                {/* Language toggle at bottom */}
+                <div className="px-5 py-4 border-t border-[var(--divider)]">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-[var(--text-muted)]">Language</span>
+                    <LanguageToggle />
                   </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
-          </motion.div>
-        </>
-      )}
-    </AnimatePresence>
+                </div>
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+
+      <OrderHistorySheet
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        restaurantId={restaurantId}
+        currency={currency || "ILS"}
+        onReorder={handleReorder}
+      />
+    </>
   );
 }

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -1599,6 +1599,8 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
         open={navDrawerOpen}
         onClose={() => setNavDrawerOpen(false)}
         restaurant={restaurant}
+        currency={menu.currency}
+        onReorder={handleReorderToCart}
       />
     </main>
   );

--- a/services/api.ts
+++ b/services/api.ts
@@ -107,12 +107,29 @@ export type GuestOrder = {
   created_at: string;
   total: number;
   items: GuestOrderItem[];
+  // Present for the full history view; omitted/ignored by the reorder sheet.
+  receipt_token?: string;
+  order_type?: OrderType;
+  order_status?: OrderStatus;
+  payment_status?: PaymentStatus;
+  item_count?: number;
 };
 
-/** The signed-in guest's recent orders for this restaurant (for reorder). */
-export async function fetchMyOrders(restaurantId: string): Promise<GuestOrder[]> {
+/**
+ * The signed-in guest's recent orders (for reorder + the account history page).
+ * Pass `restaurantId` to scope to one restaurant, or omit it for every
+ * restaurant the guest has ordered from. `limit` defaults server-side to 10.
+ */
+export async function fetchMyOrders(
+  restaurantId?: string,
+  limit?: number
+): Promise<GuestOrder[]> {
   if (!guestToken()) return [];
-  const res = await fetch(`${PUBLIC_PREFIX}/me/orders?restaurant_id=${restaurantId}`, {
+  const params = new URLSearchParams();
+  if (restaurantId) params.set("restaurant_id", restaurantId);
+  if (limit) params.set("limit", String(limit));
+  const qs = params.toString();
+  const res = await fetch(`${PUBLIC_PREFIX}/me/orders${qs ? `?${qs}` : ""}`, {
     headers: withGuestAuth(),
   });
   const data = await handleResponse<{ orders: GuestOrder[] }>(res);


### PR DESCRIPTION
## Summary

The guest app ran **two parallel identity systems**: the hamburger drawer used phone+OTP (`useGuestAuth`), while the top-bar avatar used the Google account (`useGuestAccount`). They never agreed — a guest signed in with Google still saw "Sign In" in the drawer, with different UI in each place.

This consolidates everything onto the single Google account.

### Changes
- **`NavigationDrawer`** reads `useGuestAccount`: signed in → name/email + Sign Out; signed out → the same Google sign-in button as the top bar. "My Orders" opens the shared token-based `OrderHistorySheet`. OTP flow removed from the drawer.
- **`OrderExperience`** passes currency + reorder-to-cart into the drawer.
- **Order-history pages** (`/orders` global and `/r/[slug]/orders`) rewritten to be account-based: Google sign-in when signed out, account orders when signed in, each still linking to its receipt. The global page lists across all restaurants.
- **`fetchMyOrders`** gains an optional restaurant scope + `limit`; `GuestOrder` carries the new history fields.

OTP remains only where it still earns its place: **phone verification at checkout**.

## Depends on

`foody-isr/server` companion PR (enriches `/me/orders` with `receipt_token`/status). Until that deploys, history rows render as non-clickable cards (graceful degradation, no crash).

## Validation

`npm run lint` and `npx tsc --noEmit` clean for all changed files.

https://claude.ai/code/session_016FtzqD8GyqAYLZMhw4Y797

---
_Generated by [Claude Code](https://claude.ai/code/session_016FtzqD8GyqAYLZMhw4Y797)_