### PR TITLE
Add 'image-only' category banner style

### DIFF
--- a/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
@@ -2,18 +2,20 @@ import type { CategoryBannerProps } from "./CategoryBanner";
 import { TextBlock } from "./CategoryBanner.TextBlock";
 import { roleTextStyle } from "@/lib/themes/typography";
 
-export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "cover" }: CategoryBannerProps) {
+export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "cover", hideTitle = false }: CategoryBannerProps) {
   if (!imageUrl) return <TextBlock name={name} capitalize={capitalize} />;
   const display = capitalize ? name.toUpperCase() : name;
   // Dark veil darkness is admin-configurable (0-100). The title keeps its own
-  // drop-shadow so it stays legible even when the veil is disabled.
+  // drop-shadow so it stays legible even when the veil is disabled. With
+  // hideTitle (the "image-only" style) we drop both the veil and the title so
+  // the banner shows the artwork untouched.
   const veil = Math.min(Math.max(overlay, 0), 100) / 100;
 
-  const veilEl = veil > 0 ? <div className="absolute inset-0" style={{ backgroundColor: `rgba(0,0,0,${veil})` }} /> : null;
+  const veilEl = !hideTitle && veil > 0 ? <div className="absolute inset-0" style={{ backgroundColor: `rgba(0,0,0,${veil})` }} /> : null;
   // The title overlay is identical across every fit; it's absolutely positioned
   // so it centers over the image whether the box has a fixed height or follows
   // the image's natural aspect ratio.
-  const titleEl = (
+  const titleEl = hideTitle ? null : (
     <div className="absolute inset-0 z-10 flex flex-col items-center justify-center px-4 text-center">
       <div className="w-20 sm:w-24 border-t border-white/80 mb-3 sm:mb-4" />
       {/* The responsive base size lives in the --ctb var (1.5rem mobile,

--- a/components/themed/CategoryBanner/CategoryBanner.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.tsx
@@ -14,6 +14,8 @@ export type CategoryBannerProps = {
   overlay?: number;
   /** How the image fills the banner box: "cover" (crop, default), "contain" (whole image + blurred fill), or "natural" (full-width at the image's own aspect ratio). Only used by ImageOverlay. */
   fit?: "cover" | "contain" | "natural";
+  /** When true, the image is shown with no overlaid title/veil (the "image-only" style). Only used by ImageOverlay. */
+  hideTitle?: boolean;
 };
 
 export function CategoryBanner(props: CategoryBannerProps) {
@@ -28,6 +30,7 @@ export function CategoryBanner(props: CategoryBannerProps) {
   const merged = { ...props, capitalize, overlay, fit };
   switch (style) {
     case "image-overlay": return <ImageOverlay {...merged} />;
+    case "image-only":    return <ImageOverlay {...merged} hideTitle />;
     case "text-block":    return <TextBlock {...merged} />;
     case "striped-rule":  return <StripedRule {...merged} />;
     case "none":          return null;

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -149,7 +149,7 @@ export type PreviewMessage =
         ink: string;
       } | null;
       faviconURL?: string;
-      categoryBannerStyle?: "image-overlay" | "text-block" | "striped-rule" | "none";
+      categoryBannerStyle?: "image-overlay" | "image-only" | "text-block" | "striped-rule" | "none";
       categoryBannerOverlay?: number;
       categoryBannerFit?: "cover" | "contain" | "natural";
       orderPageInfo?: OrderPageInfo | null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -506,7 +506,7 @@ export type WebsiteConfig = {
   /** Font family applied to the restaurant name overlay on the order/menu hero. */
   heroNameFont?: string;
   /** Per-restaurant override for the category section divider style on the order page. */
-  categoryBannerStyle?: 'image-overlay' | 'text-block' | 'striped-rule' | 'none';
+  categoryBannerStyle?: 'image-overlay' | 'image-only' | 'text-block' | 'striped-rule' | 'none';
   /** Darkness (0-100) of the dark veil over image-overlay banners. Defaults to 40; 0 disables it. */
   categoryBannerOverlay?: number;
   /** How image-overlay banners fill their box: "cover" (crop, default), "contain" (whole image + blurred fill), or "natural" (full-width at the image's own aspect ratio). */


### PR DESCRIPTION
## What

Adds a new category banner style, **`image-only`** — the banner image with **no overlaid title and no dark veil**, just the artwork.

## Changes

- `components/themed/CategoryBanner/CategoryBanner.tsx` — new `image-only` case renders `ImageOverlay` with a `hideTitle` flag; `hideTitle` added to `CategoryBannerProps`.
- `components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx` — `hideTitle` drops both the veil and the title overlay; the same `cover` / `contain` / `natural` fit options still apply.
- `lib/types.ts`, `lib/themes/types.ts` — widen the `categoryBannerStyle` union to include `image-only`.

Pairs with server + admin PRs.

https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML

---
_Generated by [Claude Code](https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML)_