### PR TITLE
Per-device category banner fit (Cadrage)

### DIFF
--- a/components/themed/CategoryBanner/CategoryBanner.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useResolvedTheme } from "@/lib/themes/useResolvedTheme";
+import { useIsMobileViewport } from "@/lib/themes/useViewMode";
 import { ImageOverlay } from "./CategoryBanner.ImageOverlay";
 import { TextBlock } from "./CategoryBanner.TextBlock";
 import { StripedRule } from "./CategoryBanner.StripedRule";
@@ -25,8 +26,12 @@ export function CategoryBanner(props: CategoryBannerProps) {
   const capitalize = props.capitalize ?? resolved?.layout.capitalizeBanners ?? false;
   // Default 40 preserves the legacy bg-black/40 veil; admin can dial it 0-100.
   const overlay = config?.categoryBannerOverlay ?? 40;
-  // Default "cover" preserves the legacy crop-to-fill behaviour.
-  const fit = config?.categoryBannerFit ?? "cover";
+  // Fit is configured per device; the mobile value falls back to the desktop
+  // choice when unset (empty string). `||` (not `??`) so the admin preview's
+  // '' "no override" sentinel resolves to the desktop value. Starts
+  // desktop-first on the server, resolves to mobile after mount.
+  const isMobile = useIsMobileViewport();
+  const fit = (isMobile ? config?.categoryBannerFitMobile : null) || config?.categoryBannerFit || "cover";
   const merged = { ...props, capitalize, overlay, fit };
   switch (style) {
     case "image-overlay": return <ImageOverlay {...merged} />;

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -152,6 +152,7 @@ export type PreviewMessage =
       categoryBannerStyle?: "image-overlay" | "image-only" | "text-block" | "striped-rule" | "none";
       categoryBannerOverlay?: number;
       categoryBannerFit?: "cover" | "contain" | "natural";
+      categoryBannerFitMobile?: "cover" | "contain" | "natural" | "";
       orderPageInfo?: OrderPageInfo | null;
       direction?: Direction;
       typography?: TypographyOverrides | null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -507,10 +507,12 @@ export type WebsiteConfig = {
   heroNameFont?: string;
   /** Per-restaurant override for the category section divider style on the order page. */
   categoryBannerStyle?: 'image-overlay' | 'image-only' | 'text-block' | 'striped-rule' | 'none';
-  /** Darkness (0-100) of the dark veil over image-overlay banners. Defaults to 40; 0 disables it. */
+  /** Darkness (0-100) of the dark veil over image-overlay banners. Defaults to 40; 0 disables it. Shared across devices. */
   categoryBannerOverlay?: number;
-  /** How image-overlay banners fill their box: "cover" (crop, default), "contain" (whole image + blurred fill), or "natural" (full-width at the image's own aspect ratio). */
+  /** How image-overlay banners fill their box (desktop): "cover" (crop, default), "contain" (whole image + blurred fill), or "natural" (full-width at the image's own aspect ratio). */
   categoryBannerFit?: 'cover' | 'contain' | 'natural';
+  /** Mobile override for the banner fit; empty/null inherits the desktop value. */
+  categoryBannerFitMobile?: 'cover' | 'contain' | 'natural' | '' | null;
   /** Per-role typography overrides (overall size scale + per-role font/size) for the order/menu page. */
   typography?: import("./themes/typography").TypographyOverrides | null;
   /** Custom pages (beyond home + order). Each renders at /r/<slug>/<page.slug> and appears in the nav. */

--- a/services/api.ts
+++ b/services/api.ts
@@ -215,6 +215,7 @@ export async function fetchRestaurant(idOrSlug: string): Promise<Restaurant> {
       categoryBannerStyle: data.restaurant.website_config.category_banner_style || undefined,
       categoryBannerOverlay: data.restaurant.website_config.category_banner_overlay ?? undefined,
       categoryBannerFit: data.restaurant.website_config.category_banner_fit || undefined,
+      categoryBannerFitMobile: data.restaurant.website_config.category_banner_fit_mobile || undefined,
       typography: data.restaurant.website_config.typography ?? null,
       pages: Array.isArray(data.restaurant.website_config.pages)
         ? data.restaurant.website_config.pages


### PR DESCRIPTION
Renders the category banner image fit per device.

- `CategoryBanner` picks the fit by viewport via `useIsMobileViewport()`; the mobile value inherits the desktop one when unset (`||`, so the admin preview's `''` sentinel resolves to desktop).
- Adds `categoryBannerFitMobile` to the config types and parses `category_banner_fit_mobile` in the API client + preview message.
- Banner style and overlay remain shared across devices.

https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML

---
_Generated by [Claude Code](https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML)_