### PR TITLE
Per-category banner focal point with drag-on-preview editing

### DIFF
--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -1217,6 +1217,9 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
                     name={tField(group, "name", menuLocale)}
                     description={group.description}
                     imageUrl={group.imageUrl}
+                    focalX={group.focalX}
+                    focalY={group.focalY}
+                    groupId={group.id}
                   />
                   <div className={gridClass}>
                     {groupItems.map((item) => (

--- a/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
@@ -1,8 +1,12 @@
 import type { CategoryBannerProps } from "./CategoryBanner";
 import { TextBlock } from "./CategoryBanner.TextBlock";
 import { roleTextStyle } from "@/lib/themes/typography";
+import { useBannerFocalDrag } from "./useBannerFocalDrag";
 
-export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "cover", hideTitle = false }: CategoryBannerProps) {
+export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "cover", hideTitle = false, focalX = 50, focalY = 50, editable = false, onFocalChange, onFocalCommit }: CategoryBannerProps) {
+  // Hook must run before any early return (rules of hooks). It is inert unless
+  // `editable` (admin preview); real customers get plain, non-interactive boxes.
+  const drag = useBannerFocalDrag(editable, onFocalChange, onFocalCommit);
   if (!imageUrl) return <TextBlock name={name} capitalize={capitalize} />;
   const display = capitalize ? name.toUpperCase() : name;
   // Dark veil darkness is admin-configurable (0-100). The title keeps its own
@@ -31,8 +35,23 @@ export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "
     </div>
   );
 
+  // Focal point as CSS object-position — what stays visible when the image is
+  // cropped to fill. Only meaningful when the box crops (cover/contain).
+  const objStyle = { objectPosition: `${focalX}% ${focalY}%` } as const;
+
+  // The draggable dot + crosshair cursor only render in the admin preview.
+  const focalDot = editable ? (
+    <div
+      aria-hidden
+      className="absolute z-20 w-6 h-6 -ml-3 -mt-3 rounded-full border-2 border-white bg-brand shadow-[0_0_0_2px_rgba(0,0,0,0.5)] pointer-events-none"
+      style={{ left: `${focalX}%`, top: `${focalY}%` }}
+    />
+  ) : null;
+  const editClass = editable ? "cursor-crosshair select-none touch-none" : "";
+
   // "natural": full-width image at its own aspect ratio — no fixed height, so the
   // whole graphic shows with no cropping and no letterbox on any screen width.
+  // Nothing is cropped, so the focal point has no effect here (no dot shown).
   if (fit === "natural") {
     return (
       <div className="relative my-6 rounded-2xl overflow-hidden">
@@ -47,22 +66,31 @@ export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "
   // image inside that box with a blurred, zoomed copy filling the side letterbox.
   const contain = fit === "contain";
   return (
-    <div className="relative my-6 h-40 sm:h-44 lg:h-48 rounded-2xl overflow-hidden">
+    <div
+      ref={drag.ref}
+      {...drag.handlers}
+      className={`relative my-6 h-40 sm:h-44 lg:h-48 rounded-2xl overflow-hidden ${editClass}`}
+    >
       {contain && (
         <img
           src={imageUrl}
           alt=""
           aria-hidden
           className="absolute inset-0 w-full h-full object-cover scale-110 blur-xl"
+          style={objStyle}
+          draggable={false}
         />
       )}
       <img
         src={imageUrl}
         alt=""
         className={`absolute inset-0 w-full h-full ${contain ? "object-contain" : "object-cover"}`}
+        style={objStyle}
+        draggable={false}
       />
       {veilEl}
       {titleEl}
+      {focalDot}
     </div>
   );
 }

--- a/components/themed/CategoryBanner/CategoryBanner.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { useResolvedTheme } from "@/lib/themes/useResolvedTheme";
 import { useIsMobileViewport } from "@/lib/themes/useViewMode";
+import { usePreviewMode } from "@/lib/preview-mode";
 import { ImageOverlay } from "./CategoryBanner.ImageOverlay";
 import { TextBlock } from "./CategoryBanner.TextBlock";
 import { StripedRule } from "./CategoryBanner.StripedRule";
@@ -17,6 +19,17 @@ export type CategoryBannerProps = {
   fit?: "cover" | "contain" | "natural";
   /** When true, the image is shown with no overlaid title/veil (the "image-only" style). Only used by ImageOverlay. */
   hideTitle?: boolean;
+  /** Banner image focal point (0-100, percent from left/top) → CSS object-position. */
+  focalX?: number;
+  focalY?: number;
+  /** Menu group id — only used in the admin preview to report focal edits back. */
+  groupId?: string;
+  /** Internal (injected by CategoryBanner): the banner is editable in the preview. */
+  editable?: boolean;
+  /** Internal: live focal update while dragging. */
+  onFocalChange?: (x: number, y: number) => void;
+  /** Internal: final focal value on drag release. */
+  onFocalCommit?: (x: number, y: number) => void;
 };
 
 export function CategoryBanner(props: CategoryBannerProps) {
@@ -32,7 +45,37 @@ export function CategoryBanner(props: CategoryBannerProps) {
   // desktop-first on the server, resolves to mobile after mount.
   const isMobile = useIsMobileViewport();
   const fit = (isMobile ? config?.categoryBannerFitMobile : null) || config?.categoryBannerFit || "cover";
-  const merged = { ...props, capitalize, overlay, fit };
+
+  // Focal-point editing: only active inside the admin website-editor preview.
+  // We keep an optimistic local copy so dragging is smooth, then post the final
+  // value to the parent (admin) on release; admin persists it to the group.
+  const editable = usePreviewMode();
+  const [focal, setFocal] = useState({ x: props.focalX ?? 50, y: props.focalY ?? 50 });
+  // Re-sync when the source data changes (e.g. a refetch or switching group).
+  useEffect(() => {
+    setFocal({ x: props.focalX ?? 50, y: props.focalY ?? 50 });
+  }, [props.focalX, props.focalY, props.groupId]);
+  const commit = useCallback(
+    (x: number, y: number) => {
+      setFocal({ x, y });
+      if (typeof window !== "undefined" && window.parent !== window && props.groupId) {
+        window.parent.postMessage({ type: "foody-banner-focal", groupId: props.groupId, x, y }, "*");
+      }
+    },
+    [props.groupId],
+  );
+
+  const merged = {
+    ...props,
+    capitalize,
+    overlay,
+    fit,
+    focalX: focal.x,
+    focalY: focal.y,
+    editable,
+    onFocalChange: (x: number, y: number) => setFocal({ x, y }),
+    onFocalCommit: commit,
+  };
   switch (style) {
     case "image-overlay": return <ImageOverlay {...merged} />;
     case "image-only":    return <ImageOverlay {...merged} hideTitle />;

--- a/components/themed/CategoryBanner/useBannerFocalDrag.ts
+++ b/components/themed/CategoryBanner/useBannerFocalDrag.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+function clamp(v: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+/**
+ * Drag-a-dot focal point editing for a category banner, used only inside the
+ * admin website-editor preview. Returns a ref to attach to the banner box and
+ * pointer handlers that translate a click/drag into a 0-100 focal coordinate.
+ * `onChange` fires continuously (for live object-position feedback); `onCommit`
+ * fires on release so the parent can persist the final value.
+ */
+export function useBannerFocalDrag(
+  editable: boolean,
+  onChange?: (x: number, y: number) => void,
+  onCommit?: (x: number, y: number) => void,
+) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const last = useRef({ x: 50, y: 50 });
+
+  const fromEvent = useCallback(
+    (clientX: number, clientY: number) => {
+      const el = ref.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const x = clamp(((clientX - r.left) / r.width) * 100, 0, 100);
+      const y = clamp(((clientY - r.top) / r.height) * 100, 0, 100);
+      const rx = Math.round(x * 10) / 10;
+      const ry = Math.round(y * 10) / 10;
+      last.current = { x: rx, y: ry };
+      onChange?.(rx, ry);
+    },
+    [onChange],
+  );
+
+  const handlers = editable
+    ? {
+        onPointerDown: (e: React.PointerEvent) => {
+          e.preventDefault();
+          (e.target as Element).setPointerCapture?.(e.pointerId);
+          setDragging(true);
+          fromEvent(e.clientX, e.clientY);
+        },
+        onPointerMove: (e: React.PointerEvent) => {
+          if (dragging) fromEvent(e.clientX, e.clientY);
+        },
+        onPointerUp: (e: React.PointerEvent) => {
+          if (!dragging) return;
+          setDragging(false);
+          (e.target as Element).releasePointerCapture?.(e.pointerId);
+          onCommit?.(last.current.x, last.current.y);
+        },
+        onPointerCancel: () => {
+          if (!dragging) return;
+          setDragging(false);
+          onCommit?.(last.current.x, last.current.y);
+        },
+      }
+    : {};
+
+  return { ref, handlers, dragging };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,10 @@ export type MenuGroup = {
   description?: string;
   slug?: string;
   imageUrl?: string;
+  /** Banner image focal point (0-100, percent from left/top) used as CSS
+   *  object-position when the banner is cropped to fill. Default 50/50. */
+  focalX?: number;
+  focalY?: number;
   translations?: import("./translations").TranslationMap | null;
 };
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -290,6 +290,8 @@ function _mapCategories(rawCats: Array<{ id: number; name?: string; Name?: strin
     id: String(c.id),
     name: c.name || c.Name || "Category",
     imageUrl: c.image_url || c.imageUrl || "",
+    focalX: typeof c.banner_focal_x === "number" ? c.banner_focal_x : 50,
+    focalY: typeof c.banner_focal_y === "number" ? c.banner_focal_y : 50,
     translations: c.translations || c.Translations || null,
   }));
   const items: MenuItem[] = rawCats.flatMap((c) =>


### PR DESCRIPTION
Renders and edits the per-category banner focal point.

- `CategoryBanner` / `ImageOverlay` apply each group's focal point as CSS `object-position` on the cropped banner image (`cover` / `contain` fits). Real customers just see the chosen crop; default 50/50 is unchanged from before.
- Inside the admin website-editor preview (`usePreviewMode`), a new `useBannerFocalDrag` hook renders a draggable dot (same metaphor as the background focal picker) and translates a click/drag into a 0–100 focal coordinate. On release it `postMessage`s `foody-banner-focal` to the parent admin window to persist.
- Parses `banner_focal_x/y` from the menu API into `MenuGroup.focalX/Y`.

Accompanies the server (focal columns) and admin (persist) PRs.

https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML

---
_Generated by [Claude Code](https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML)_