### PR TITLE
Per-section color overrides for navbar, hero, metadata, category bar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -114,17 +114,17 @@ body {
    bar at a comfortable height now that the buttons themselves are compact. */
 .category-tab {
   @apply my-3 px-4 py-2 rounded-full text-base font-medium whitespace-nowrap transition-colors duration-200;
-  color: var(--text-soft);
+  color: var(--cat-text, var(--text-soft));
 }
 
 .category-tab:hover {
-  color: var(--text);
-  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--cat-text, var(--text));
+  background: color-mix(in srgb, var(--cat-text, var(--text)) 8%, transparent);
 }
 
 .category-tab.active {
-  color: var(--brand);
-  background: color-mix(in srgb, var(--brand) 15%, transparent);
+  color: var(--cat-accent, var(--brand));
+  background: color-mix(in srgb, var(--cat-accent, var(--brand)) 15%, transparent);
 }
 
 /* Price styling - Wolt uses cyan, we use brand orange */

--- a/components/CategoryTabs.tsx
+++ b/components/CategoryTabs.tsx
@@ -149,10 +149,11 @@ export function GroupTabs({
       ref={barRef}
       className={clsx(
         "sticky top-0 md:top-14 z-40 transition-colors duration-200 border-b",
-        stuck
-          ? "bg-[var(--surface)] border-[var(--divider)]"
-          : "bg-[var(--bg-page)] border-transparent",
+        stuck ? "border-[var(--divider)]" : "border-transparent",
       )}
+      // Background follows the category-bar override when set, otherwise the
+      // stuck/at-rest theme tokens (surface when pinned, page bg at rest).
+      style={{ backgroundColor: stuck ? "var(--cat-bg, var(--surface))" : "var(--cat-bg, var(--bg-page))" }}
     >
       {onSearch && (
         <div className="block md:hidden px-4 pt-4 pb-1">

--- a/components/RestaurantHero.tsx
+++ b/components/RestaurantHero.tsx
@@ -294,7 +294,8 @@ export function RestaurantHero({
 
   const infoRow = (justify: string) => (
     <div
-      className={`flex flex-wrap items-center ${justify} gap-x-2 gap-y-1 text-[12px] sm:text-[13px] font-medium text-[var(--text-muted)]`}
+      style={{ color: "var(--meta-text, var(--text-muted))" }}
+      className={`flex flex-wrap items-center ${justify} gap-x-2 gap-y-1 text-[12px] sm:text-[13px] font-medium`}
     >
       {rowItems.map((node, i) => (
         <span key={i} className="inline-flex items-center gap-x-2">
@@ -398,7 +399,8 @@ export function RestaurantHero({
           the order-type / fulfilment chip, then the info segments. pt clears
           the straddling logo above it. */}
       <div
-        className={`hidden sm:flex items-center flex-wrap gap-x-3 gap-y-2 bg-[var(--bg-page)] border-b border-[var(--divider)] pt-9 pb-5 pe-6 lg:pe-12 ${
+        style={{ backgroundColor: "var(--meta-bg, var(--bg-page))" }}
+        className={`hidden sm:flex items-center flex-wrap gap-x-3 gap-y-2 border-b border-[var(--divider)] pt-9 pb-5 pe-6 lg:pe-12 ${
           webOrderChip
             ? "ps-6 lg:ps-12"
             : // No leading chip: bare text starts at the rail, which reads
@@ -415,15 +417,15 @@ export function RestaurantHero({
       {/* MOBILE brand band — centered name + compact info line on the page
           background. pt-10 leaves room for the logo straddling in from the
           cover above. */}
-      <div className="sm:hidden relative bg-[var(--bg-page)] px-5 pt-10 pb-6 text-center">
+      <div className="sm:hidden relative px-5 pt-10 pb-6 text-center" style={{ backgroundColor: "var(--hero-bg, var(--bg-page))" }}>
         {tagline && (
           <p className="text-[10.5px] font-bold uppercase tracking-[0.16em] text-[var(--text-soft)] mb-1.5">
             {tagline}
           </p>
         )}
         <h1
-          className="text-[31px] leading-[1.04] font-extrabold tracking-[-0.02em] text-[var(--text)]"
-          style={nameFontStyle}
+          className="text-[31px] leading-[1.04] font-extrabold tracking-[-0.02em]"
+          style={{ ...nameFontStyle, color: "var(--hero-text, var(--text))" }}
         >
           {restaurant.name}
         </h1>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -69,8 +69,9 @@ export function TopBar({ restaurant, onMenuToggle, viewMode, onToggleViewMode, s
       barBgClass = "shadow-[0_1px_0_0_rgba(255,255,255,0.1)]";
       barBgStyle = { backgroundColor: navbarColor };
     } else {
-      barBgClass = "bg-[var(--surface)] shadow-[0_1px_0_0_var(--divider)]";
-      barBgStyle = undefined;
+      // Solid bar: the per-section navbar override wins, else the theme surface.
+      barBgClass = "shadow-[0_1px_0_0_var(--divider)]";
+      barBgStyle = { backgroundColor: "var(--navbar-bg, var(--surface))" };
     }
   } else {
     barBgClass = "bg-transparent";
@@ -84,7 +85,13 @@ export function TopBar({ restaurant, onMenuToggle, viewMode, onToggleViewMode, s
     ? "bg-black/45 hover:bg-black/60 backdrop-blur-md"
     : "bg-[var(--surface-subtle)] hover:bg-[var(--divider)]";
   const iconColorClass = overHero ? "text-white" : "text-[var(--text-primary)]";
-  const nameColorClass = scrolled && !isCustomNav && !isTransparentNav ? "text-[var(--text)]" : "text-white";
+  // Over the hero the name is white for legibility; once the solid bar shows it
+  // uses the per-section navbar text override (falling back to the theme ink).
+  const nameThemed = scrolled && !isCustomNav && !isTransparentNav;
+  const nameColorClass = nameThemed ? "" : "text-white";
+  const nameColorStyle: React.CSSProperties | undefined = nameThemed
+    ? { color: "var(--navbar-text, var(--text))" }
+    : undefined;
 
   return (
     <header
@@ -116,7 +123,7 @@ export function TopBar({ restaurant, onMenuToggle, viewMode, onToggleViewMode, s
           {/* The logo lives only on the hero now (Wolt-style brand band), never
               in the top bar. The bar keeps just the restaurant name. */}
           {!hideNavbarName && (
-            <span className={`font-bold text-sm truncate max-w-[180px] transition ${nameColorClass}`}>
+            <span className={`font-bold text-sm truncate max-w-[180px] transition ${nameColorClass}`} style={nameColorStyle}>
               {restaurant?.name || ""}
             </span>
           )}

--- a/lib/themes/applyTheme.ts
+++ b/lib/themes/applyTheme.ts
@@ -186,3 +186,48 @@ export function clearTheme(): void {
   }
   root.style.removeProperty("color-scheme");
 }
+
+// ── Per-section color overrides ──────────────────────────────────────────────
+// Scoped CSS vars consumed by the navbar, hero, metadata row and category bar,
+// each with a fallback to its global token (e.g. var(--cat-bg, var(--surface))).
+// We only set a var when the admin provides an override, so an unset section is
+// pixel-identical to the global theme.
+
+/** Minimal structural shape — kept local to avoid a types import cycle. */
+type SectionColorsInput = {
+  navbar?: { bg?: string; text?: string } | null;
+  hero?: { bg?: string; text?: string } | null;
+  metadata?: { bg?: string; text?: string } | null;
+  categoryBar?: { bg?: string; text?: string; accent?: string } | null;
+} | null | undefined;
+
+const SECTION_VAR_NAMES = [
+  "--navbar-bg", "--navbar-text",
+  "--hero-bg", "--hero-text",
+  "--meta-bg", "--meta-text",
+  "--cat-bg", "--cat-text", "--cat-accent",
+];
+
+export function applySectionColors(sc: SectionColorsInput): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  const set = (name: string, val?: string) => {
+    if (val) root.style.setProperty(name, val);
+    else root.style.removeProperty(name);
+  };
+  set("--navbar-bg", sc?.navbar?.bg);
+  set("--navbar-text", sc?.navbar?.text);
+  set("--hero-bg", sc?.hero?.bg);
+  set("--hero-text", sc?.hero?.text);
+  set("--meta-bg", sc?.metadata?.bg);
+  set("--meta-text", sc?.metadata?.text);
+  set("--cat-bg", sc?.categoryBar?.bg);
+  set("--cat-text", sc?.categoryBar?.text);
+  set("--cat-accent", sc?.categoryBar?.accent);
+}
+
+export function clearSectionColors(): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  for (const prop of SECTION_VAR_NAMES) root.style.removeProperty(prop);
+}

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -148,6 +148,7 @@ export type PreviewMessage =
         accent: string;
         ink: string;
       } | null;
+      sectionColors?: import("@/lib/types").SectionColors | null;
       faviconURL?: string;
       categoryBannerStyle?: "image-overlay" | "image-only" | "text-block" | "striped-rule" | "none";
       categoryBannerOverlay?: number;

--- a/lib/themes/useResolvedTheme.tsx
+++ b/lib/themes/useResolvedTheme.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useEffect, useMemo, useState, ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { themesById, pairingsById } from "./generated/themes";
-import { applyTheme, clearTheme, shade } from "./applyTheme";
+import { applyTheme, clearTheme, applySectionColors, clearSectionColors, shade } from "./applyTheme";
 import { contrastInk } from "./contrastInk";
 import { pickFont } from "./pickFont";
 import type { ResolvedTheme, Direction, PreviewMessage } from "./types";
@@ -147,6 +147,17 @@ export function ResolvedThemeProvider({ config, direction = "ltr", children }: P
     if (resolved) applyTheme(resolved);
     return () => clearTheme();
   }, [resolved, onOrderRoute]);
+
+  // Per-section color overrides layer on top of the theme. Separate effect so a
+  // change to only the section colors (not the theme) still re-applies them.
+  useEffect(() => {
+    if (!onOrderRoute) {
+      clearSectionColors();
+      return;
+    }
+    applySectionColors(effectiveConfig?.sectionColors);
+    return () => clearSectionColors();
+  }, [effectiveConfig?.sectionColors, onOrderRoute]);
 
   // Live-update the favicon when admin sets it. Browsers don't always pick
   // up changes to the existing <link rel="icon"> href, so we replace the node.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -464,6 +464,15 @@ export type WebsitePage = {
   sortOrder: number;
 };
 
+/** Optional per-section color overrides (hex strings). Any omitted section or
+ *  field falls back to the global theme token for that color. */
+export type SectionColors = {
+  navbar?: { bg?: string; text?: string };
+  hero?: { bg?: string; text?: string };
+  metadata?: { bg?: string; text?: string };
+  categoryBar?: { bg?: string; text?: string; accent?: string };
+};
+
 export type WebsiteConfig = {
   // Theme system (menu/order page)
   themeId: string;
@@ -507,6 +516,9 @@ export type WebsiteConfig = {
     accent: string;
     ink: string;
   };
+  /** Optional per-section color overrides layered on top of the active theme.
+   *  Any missing section/field inherits the global theme color. */
+  sectionColors?: SectionColors | null;
   /** Font family applied to the restaurant name overlay on the order/menu hero. */
   heroNameFont?: string;
   /** Per-restaurant override for the category section divider style on the order page. */

--- a/services/api.ts
+++ b/services/api.ts
@@ -211,6 +211,7 @@ export async function fetchRestaurant(idOrSlug: string): Promise<Restaurant> {
       hideHeroLogo: data.restaurant.website_config.hide_hero_logo ?? false,
       heroLogoBg: data.restaurant.website_config.hero_logo_bg === 'black' ? 'black' : 'white',
       customPalette: data.restaurant.website_config.custom_palette || undefined,
+      sectionColors: data.restaurant.website_config.section_colors || null,
       heroNameFont: data.restaurant.website_config.hero_name_font || undefined,
       categoryBannerStyle: data.restaurant.website_config.category_banner_style || undefined,
       categoryBannerOverlay: data.restaurant.website_config.category_banner_overlay ?? undefined,


### PR DESCRIPTION
Renders optional per-section color overrides for the order page.

- `applySectionColors()` sets scoped CSS vars (`--navbar-bg/text`, `--hero-bg/text`, `--meta-bg/text`, `--cat-bg/text/accent`) from `WebsiteConfig.sectionColors`, on order routes only; `clearSectionColors()` on teardown.
- Each consuming spot falls back to its global token — e.g. `var(--cat-bg, var(--surface))` — so an **unset section is pixel-identical to before**. Touched: `TopBar` (navbar solid bar bg + name), `RestaurantHero` (mobile hero band + name, desktop metadata band + info text), `CategoryTabs` + `globals.css` (bar bg, pill text, active-pill accent).
- Parses `section_colors` in the API client and carries `sectionColors` in the preview message for live editing.

Nuances: navbar override applies to the solid (scrolled) bar; hero bg/text mainly affect the mobile brand band (the desktop name sits on the cover image), while metadata bg affects the desktop info band.

Accompanies the server (`section_colors` column) and admin (editor UI) PRs.

https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML

---
_Generated by [Claude Code](https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML)_