### PR TITLE
Reflect one-click order pause on the storefront

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -359,7 +359,7 @@ function CheckoutContent() {
         // Update local state so the UI reflects fresh data
         setRestaurant(freshRestaurant);
 
-        if (freshRestaurant.rushMode) {
+        if (freshRestaurant.rushMode || freshRestaurant.ordersPaused) {
           throw new Error(
             `Sorry, ${freshRestaurant.name} is temporarily paused and not accepting new orders right now.`
           );

--- a/components/AvailabilityBanner.tsx
+++ b/components/AvailabilityBanner.tsx
@@ -12,8 +12,8 @@ export function AvailabilityBanner({
   restaurant,
   serviceType,
 }: AvailabilityBannerProps) {
-  // Rush mode takes priority
-  if (restaurant.rushMode) {
+  // A paused storefront (rush mode or the one-click pause) takes priority
+  if (restaurant.rushMode || restaurant.ordersPaused) {
     return (
       <div className="mx-4 mt-4 rounded-2xl border border-amber-200 bg-amber-50 p-5 text-center">
         <div className="text-3xl mb-2">⏸️</div>

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -193,7 +193,8 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
     restaurant.timezone || "UTC",
     restaurant.batchFulfillmentEnabled
   );
-  const isRestaurantOpen = currentAvailability.isOpen && !restaurant.rushMode;
+  const isRestaurantOpen =
+    currentAvailability.isOpen && !restaurant.rushMode && !restaurant.ordersPaused;
 
   useEffect(() => {
     setContext(restaurantId, menu.currency);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -431,6 +431,7 @@ export type Restaurant = {
   aiAssistantTriggerDelay?: number; // seconds before the delayed proactive prompt
   serviceMode?: "counter" | "table"; // counter = day mode (customer picks up), table = night mode (waiter delivers)
   rushMode?: boolean; // When true, restaurant is temporarily paused
+  ordersPaused?: boolean; // Effective one-click pause (expiry already applied server-side)
   tipsEnabled?: boolean; // When false, skip the tip step for customers
   // OTP mode for guest checkout (pickup/delivery):
   //   "required" — phone + code (default, current behaviour)

--- a/services/api.ts
+++ b/services/api.ts
@@ -175,6 +175,7 @@ export async function fetchRestaurant(idOrSlug: string): Promise<Restaurant> {
     aiAssistantTriggerDelay: data.restaurant.ai_assistant_trigger_delay ?? 45,
     serviceMode: data.restaurant.service_mode || undefined,
     rushMode: data.restaurant.rush_mode ?? false,
+    ordersPaused: data.restaurant.orders_paused ?? false,
     tipsEnabled: data.restaurant.tips_enabled ?? true,
     otpMode: data.restaurant.otp_mode === 'skip' ? 'skip' : 'required',
     schedulingEnabled: data.restaurant.scheduling_enabled ?? false,


### PR DESCRIPTION
## Why

Admin's one-click Pause (`orders_paused`) blocked order submission server-side, but the guest site only reacted to `rush_mode` — so a paused restaurant showed customers no banner and let them build a cart only to fail at checkout.

## What

Treat `orders_paused` the same as `rush_mode` for the storefront's closed state:
- Parse `orders_paused` → `Restaurant.ordersPaused` (`services/api.ts`, `lib/types.ts`)
- `AvailabilityBanner`, `OrderExperience`, and checkout now block + show the paused state when `rushMode || ordersPaused`

The server already exposes an effective (expiry-aware) `orders_paused`, so the optional reopen time is respected automatically.

## Verification

`tsc --noEmit` ✓ · `npm run lint` ✓

https://claude.ai/code/session_01KjrTUGGTjAr7XDsn4wRp8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjrTUGGTjAr7XDsn4wRp8M)_