### PR TITLE
Render 'color-title' category banners (bg color + title + stickers)

### DIFF
--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -1219,6 +1219,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
                     imageUrl={group.imageUrl}
                     focalX={group.focalX}
                     focalY={group.focalY}
+                    design={group.bannerDesign}
                     groupId={group.id}
                   />
                   <div className={gridClass}>

--- a/components/themed/CategoryBanner/CategoryBanner.ColorTitle.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ColorTitle.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import type { BannerDesign, BannerSticker } from "@/lib/types";
+import type { CategoryBannerProps } from "./CategoryBanner";
+import { roleTextStyle } from "@/lib/themes/typography";
+import { ensureFont } from "@/components/sections/typography";
+
+function clamp(v: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function postToParent(msg: unknown) {
+  if (typeof window !== "undefined" && window.parent !== window) {
+    window.parent.postMessage(msg, "*");
+  }
+}
+
+/**
+ * "Couleur + titre" category banner: a solid background color, a styled title
+ * (the category name or custom text), and any number of positioned/rotated
+ * sticker images. Inside the admin website-editor preview it is interactive —
+ * clicking selects the banner (so the admin shows its controls) and stickers
+ * can be dragged; every change is posted to the parent admin to persist.
+ */
+export function ColorTitle({ name, capitalize, design: designProp, groupId, editable = false }: CategoryBannerProps) {
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const [design, setDesign] = useState<BannerDesign>(designProp ?? {});
+
+  // Re-sync from props (initial data / refetch / group switch).
+  useEffect(() => {
+    setDesign(designProp ?? {});
+  }, [designProp, groupId]);
+
+  // In the editor, the admin pushes live design edits (bg/title/sticker add)
+  // targeted at this group; apply them so the preview updates as they type.
+  useEffect(() => {
+    if (!editable) return;
+    function onMessage(e: MessageEvent) {
+      if (e.data?.type === "foody-banner-design" && String(e.data.groupId) === String(groupId)) {
+        setDesign((e.data.design ?? {}) as BannerDesign);
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [editable, groupId]);
+
+  const td = design.title ?? {};
+  useEffect(() => {
+    if (td.font) ensureFont(td.font);
+  }, [td.font]);
+
+  // ── Sticker drag (editor only) ──
+  const dragState = useRef<{ id: string } | null>(null);
+  const updateStickerPos = useCallback((id: string, clientX: number, clientY: number) => {
+    const box = boxRef.current;
+    if (!box) return;
+    const r = box.getBoundingClientRect();
+    let x = clamp(((clientX - r.left) / r.width) * 100, 0, 100);
+    let y = clamp(((clientY - r.top) / r.height) * 100, 0, 100);
+    // Light edge snapping so corners are easy to hit.
+    if (x < 10) x = 8; else if (x > 90) x = 92;
+    if (y < 12) y = 10; else if (y > 88) y = 90;
+    setDesign((d) => ({
+      ...d,
+      stickers: (d.stickers ?? []).map((s) => (s.id === id ? { ...s, xPct: Math.round(x * 10) / 10, yPct: Math.round(y * 10) / 10 } : s)),
+    }));
+  }, []);
+
+  const onStickerPointerDown = (e: React.PointerEvent, id: string) => {
+    if (!editable) return;
+    e.stopPropagation();
+    e.preventDefault();
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+    dragState.current = { id };
+    updateStickerPos(id, e.clientX, e.clientY);
+  };
+  const onStickerPointerMove = (e: React.PointerEvent, id: string) => {
+    if (!editable || dragState.current?.id !== id) return;
+    updateStickerPos(id, e.clientX, e.clientY);
+  };
+  const onStickerPointerUp = (e: React.PointerEvent, id: string) => {
+    if (!editable || dragState.current?.id !== id) return;
+    dragState.current = null;
+    (e.target as Element).releasePointerCapture?.(e.pointerId);
+    // Commit the final position (read latest from state via functional update).
+    setDesign((d) => {
+      if (groupId) postToParent({ type: "foody-banner-design-change", groupId, design: d });
+      return d;
+    });
+  };
+
+  const selectBanner = () => {
+    if (editable && groupId) postToParent({ type: "foody-select-banner", groupId, design });
+  };
+
+  // ── Render ──
+  const rawText = td.text && td.text.trim() ? td.text : name;
+  const display = capitalize ? rawText.toUpperCase() : rawText;
+
+  const titleStyle: CSSProperties = {
+    ...roleTextStyle("categoryTitle", "2rem", "display", 700),
+    color: td.color || "var(--text)",
+    textAlign: td.align || "center",
+    lineHeight: 1.05,
+  };
+  if (td.font) titleStyle.fontFamily = `"${td.font}", var(--font-display), sans-serif`;
+  if (td.size && td.size !== 1) titleStyle.fontSize = `calc(2rem * var(--type-scale, 1) * ${td.size})`;
+
+  const justify = td.align === "left" ? "flex-start" : td.align === "right" ? "flex-end" : "center";
+
+  return (
+    <div
+      ref={boxRef}
+      onPointerDown={selectBanner}
+      className={`relative my-6 h-40 sm:h-44 lg:h-48 rounded-2xl overflow-hidden flex items-center px-5 ${editable ? "cursor-pointer ring-1 ring-black/5" : ""}`}
+      style={{ backgroundColor: design.bgColor || "var(--surface)", justifyContent: justify }}
+    >
+      <h2 className="relative z-10 font-display max-w-full" style={titleStyle}>
+        {display}
+      </h2>
+
+      {(design.stickers ?? []).map((s: BannerSticker) => (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          key={s.id}
+          src={s.imageUrl}
+          alt=""
+          draggable={false}
+          onPointerDown={(e) => onStickerPointerDown(e, s.id)}
+          onPointerMove={(e) => onStickerPointerMove(e, s.id)}
+          onPointerUp={(e) => onStickerPointerUp(e, s.id)}
+          onPointerCancel={(e) => onStickerPointerUp(e, s.id)}
+          className={`absolute z-20 select-none ${editable ? "cursor-move touch-none" : "pointer-events-none"}`}
+          style={{
+            left: `${s.xPct}%`,
+            top: `${s.yPct}%`,
+            width: `${s.widthPct}%`,
+            transform: `translate(-50%, -50%) rotate(${s.rotationDeg}deg)`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/themed/CategoryBanner/CategoryBanner.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.tsx
@@ -7,12 +7,16 @@ import { usePreviewMode } from "@/lib/preview-mode";
 import { ImageOverlay } from "./CategoryBanner.ImageOverlay";
 import { TextBlock } from "./CategoryBanner.TextBlock";
 import { StripedRule } from "./CategoryBanner.StripedRule";
+import { ColorTitle } from "./CategoryBanner.ColorTitle";
+import type { BannerDesign } from "@/lib/types";
 
 export type CategoryBannerProps = {
   name: string;
   imageUrl?: string;
   description?: string;
   capitalize?: boolean;
+  /** Per-category "color + title" design — only used by the ColorTitle style. */
+  design?: BannerDesign | null;
   /** Darkness (0-100) of the dark veil over the image. Only used by ImageOverlay. */
   overlay?: number;
   /** How the image fills the banner box: "cover" (crop, default), "contain" (whole image + blurred fill), or "natural" (full-width at the image's own aspect ratio). Only used by ImageOverlay. */
@@ -81,6 +85,7 @@ export function CategoryBanner(props: CategoryBannerProps) {
     case "image-only":    return <ImageOverlay {...merged} hideTitle />;
     case "text-block":    return <TextBlock {...merged} />;
     case "striped-rule":  return <StripedRule {...merged} />;
+    case "color-title":   return <ColorTitle {...merged} />;
     case "none":          return null;
     default:              return <ImageOverlay {...merged} />;
   }

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -150,7 +150,7 @@ export type PreviewMessage =
       } | null;
       sectionColors?: import("@/lib/types").SectionColors | null;
       faviconURL?: string;
-      categoryBannerStyle?: "image-overlay" | "image-only" | "text-block" | "striped-rule" | "none";
+      categoryBannerStyle?: "image-overlay" | "image-only" | "text-block" | "striped-rule" | "color-title" | "none";
       categoryBannerOverlay?: number;
       categoryBannerFit?: "cover" | "contain" | "natural";
       categoryBannerFitMobile?: "cover" | "contain" | "natural" | "";

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,32 @@
+/** One image placed on a "color-title" category banner. Position is the sticker
+ *  CENTER as a percent of the banner box; width is a percent of the banner width. */
+export type BannerSticker = {
+  id: string;
+  imageUrl: string;
+  xPct: number;
+  yPct: number;
+  widthPct: number;
+  rotationDeg: number;
+};
+
+/** Title styling for a "color-title" banner. Empty fields inherit: text → the
+ *  category name, font → the categoryTitle role, color → the theme ink. */
+export type BannerTitleDesign = {
+  text?: string;
+  font?: string;
+  size?: number; // multiplier, 1 = unchanged
+  color?: string;
+  align?: "left" | "center" | "right";
+};
+
+/** Per-category "color + title" banner design (used when the restaurant's
+ *  category banner style is "color-title"). */
+export type BannerDesign = {
+  bgColor?: string;
+  title?: BannerTitleDesign;
+  stickers?: BannerSticker[];
+};
+
 /** A menu group (display container for items within a menu). */
 export type MenuGroup = {
   id: string;
@@ -9,6 +38,8 @@ export type MenuGroup = {
    *  object-position when the banner is cropped to fill. Default 50/50. */
   focalX?: number;
   focalY?: number;
+  /** Per-category "color + title" banner design. */
+  bannerDesign?: BannerDesign | null;
   translations?: import("./translations").TranslationMap | null;
 };
 
@@ -522,7 +553,7 @@ export type WebsiteConfig = {
   /** Font family applied to the restaurant name overlay on the order/menu hero. */
   heroNameFont?: string;
   /** Per-restaurant override for the category section divider style on the order page. */
-  categoryBannerStyle?: 'image-overlay' | 'image-only' | 'text-block' | 'striped-rule' | 'none';
+  categoryBannerStyle?: 'image-overlay' | 'image-only' | 'text-block' | 'striped-rule' | 'color-title' | 'none';
   /** Darkness (0-100) of the dark veil over image-overlay banners. Defaults to 40; 0 disables it. Shared across devices. */
   categoryBannerOverlay?: number;
   /** How image-overlay banners fill their box (desktop): "cover" (crop, default), "contain" (whole image + blurred fill), or "natural" (full-width at the image's own aspect ratio). */

--- a/services/api.ts
+++ b/services/api.ts
@@ -293,6 +293,7 @@ function _mapCategories(rawCats: Array<{ id: number; name?: string; Name?: strin
     imageUrl: c.image_url || c.imageUrl || "",
     focalX: typeof c.banner_focal_x === "number" ? c.banner_focal_x : 50,
     focalY: typeof c.banner_focal_y === "number" ? c.banner_focal_y : 50,
+    bannerDesign: c.banner_design ?? null,
     translations: c.translations || c.Translations || null,
   }));
   const items: MenuItem[] = rawCats.flatMap((c) =>


### PR DESCRIPTION
Renders the new `color-title` category banner.

- New `ColorTitle` banner: a solid **background color**, a styled **title** (the category name or custom text, with font/size/color/alignment), and any number of **sticker images** placed by center-percent position, width-percent size and rotation.
- Parses `banner_design` from the menu API into `MenuGroup.bannerDesign`; `color-title` added to the banner-style unions + preview message.
- Inside the admin website-editor preview it is interactive: clicking a banner posts `foody-select-banner` (admin opens its designer) and stickers can be dragged (`foody-banner-design-change` posted back to persist). Admin pushes live edits via `foody-banner-design`. Customers see a static, non-interactive banner.

Accompanies the server (`banner_design`) and admin (designer UI) PRs.

https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML

---
_Generated by [Claude Code](https://claude.ai/code/session_01To4Nv5PbKjaPAy2Wx8DiML)_