### PR TITLE
feat(checkout): autofill saved delivery address for signed-in guests

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -247,7 +247,16 @@ function CheckoutContent() {
     if (guestAccount.phone) {
       setCustomerPhone((prev) => prev || guestAccount.phone!.replace(/^\+972/, ""));
     }
-  }, [guestAccount]);
+    // Autofill the saved delivery address for returning guests (delivery only).
+    // Never overwrites anything the guest already typed.
+    if (orderType === "delivery") {
+      if (guestAccount.address) setDeliveryAddress((prev) => prev || guestAccount.address!);
+      if (guestAccount.city) setDeliveryCity((prev) => prev || guestAccount.city!);
+      if (guestAccount.floor) setDeliveryFloor((prev) => prev || guestAccount.floor!);
+      if (guestAccount.apt) setDeliveryApt((prev) => prev || guestAccount.apt!);
+      if (guestAccount.delivery_notes) setDeliveryNotes((prev) => prev || guestAccount.delivery_notes!);
+    }
+  }, [guestAccount, orderType]);
 
   // Redirect if cart is empty (but not after order is placed). Skipped in
   // preview mode so the foodyadmin editor can show the form without a cart.

--- a/services/api.ts
+++ b/services/api.ts
@@ -70,7 +70,20 @@ function withGuestAuth(headers: Record<string, string> = {}): Record<string, str
   return token ? { ...headers, Authorization: `Bearer ${token}` } : headers;
 }
 
-export type GuestAuthAccount = { id: number; email: string; name: string; picture?: string; phone?: string };
+export type GuestAuthAccount = {
+  id: number;
+  email: string;
+  name: string;
+  picture?: string;
+  phone?: string;
+  // Saved delivery address (set from past delivery orders / edited in the admin),
+  // used to autofill the checkout for returning signed-in guests.
+  address?: string;
+  city?: string;
+  floor?: string;
+  apt?: string;
+  delivery_notes?: string;
+};
 
 /** Refresh the signed-in guest's account (e.g. phone backfilled from orders). */
 export async function fetchMe(): Promise<GuestAuthAccount | null> {


### PR DESCRIPTION
Returning guests who signed in with Google get their saved delivery address (address, city, floor, apt, notes) pre-filled at checkout.

## Changes
- `GuestAuthAccount` type extended with the saved address fields returned by `/me`.
- Checkout prefill effect fills delivery fields from the account — delivery orders only, and never overwrites anything the guest already typed.

Depends on the matching server PR (`foody-isr/server`) which adds the fields to `/me`.

## Validation
`node_modules` weren't installable in the build container, so `tsc`/`next lint` were not run here — please confirm CI is green before relying on the merge.

https://claude.ai/code/session_01JekAHsoUG6N39MXB8BkBDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01JekAHsoUG6N39MXB8BkBDz)_