### PR TITLE
Add optional email field at guest checkout

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -116,6 +116,7 @@ function CheckoutContent() {
   const [step, setStep] = useState<CheckoutStep>("details");
   const [customerName, setCustomerName] = useState("");
   const [customerPhone, setCustomerPhone] = useState("");
+  const [customerEmail, setCustomerEmail] = useState("");
   const [countryCode, setCountryCode] = useState("+972");
   const [deliveryAddress, setDeliveryAddress] = useState("");
   const [deliveryCity, setDeliveryCity] = useState("");
@@ -244,6 +245,7 @@ function CheckoutContent() {
   useEffect(() => {
     if (!guestAccount) return;
     if (guestAccount.name) setCustomerName((prev) => prev || guestAccount.name);
+    if (guestAccount.email) setCustomerEmail((prev) => prev || guestAccount.email);
     if (guestAccount.phone) {
       setCustomerPhone((prev) => prev || guestAccount.phone!.replace(/^\+972/, ""));
     }
@@ -410,6 +412,7 @@ function CheckoutContent() {
         orderType,
         customerName,
         customerPhone: normalizePhone(customerPhone),
+        customerEmail: customerEmail.trim() || undefined,
         deliveryAddress: orderType === "delivery" ? deliveryAddress : undefined,
         deliveryCity: orderType === "delivery" ? deliveryCity : undefined,
         deliveryFloor: orderType === "delivery" ? deliveryFloor : undefined,
@@ -789,6 +792,21 @@ function CheckoutContent() {
                         <p className="text-xs text-[var(--text-muted)] mt-1">
                           {orderType === "dine_in" || otpSkipMode ? t("phoneOptional") : t("verifyPhoneDescription")}
                         </p>
+                      </div>
+
+                      <div>
+                        <label className="block text-sm font-medium text-[var(--text-muted)] mb-1">
+                          {t("email")}
+                        </label>
+                        <input
+                          type="email"
+                          value={customerEmail}
+                          onChange={(e) => setCustomerEmail(e.target.value)}
+                          className="w-full px-4 py-3 border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
+                          placeholder="you@example.com"
+                          dir="ltr"
+                        />
+                        <p className="text-xs text-[var(--text-muted)] mt-1">{t("emailOptional")}</p>
                       </div>
 
                       {orderType === "delivery" && (

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -252,6 +252,7 @@ const translations: Record<Locale, Record<string, string>> = {
     confirmAndPay: "Confirm & Pay",
     confirmAndOrder: "Confirm Order",
     phoneOptional: "Optional — for receipt only",
+    emailOptional: "Optional — we'll email your confirmation",
     dineInDetails: "Your Details",
     // Session bar / dine-in continuity
     sessionBarTapItemsToStart: "Tap items to start ordering",
@@ -686,6 +687,7 @@ const translations: Record<Locale, Record<string, string>> = {
     confirmAndPay: "אשר ושלם",
     confirmAndOrder: "אשר הזמנה",
     phoneOptional: "אופציונלי — לקבלה בלבד",
+    emailOptional: "אופציונלי — נשלח לך אישור במייל",
     dineInDetails: "הפרטים שלך",
     // Session bar / dine-in continuity
     sessionBarTapItemsToStart: "הקש על פריט כדי להתחיל",
@@ -1126,6 +1128,7 @@ const translations: Record<Locale, Record<string, string>> = {
     confirmAndPay: "Confirmer et payer",
     confirmAndOrder: "Confirmer la commande",
     phoneOptional: "Optionnel — pour le reçu uniquement",
+    emailOptional: "Optionnel — nous enverrons votre confirmation par e-mail",
     dineInDetails: "Vos coordonnées",
     // Session bar / dine-in continuity
     sessionBarTapItemsToStart: "Touchez un plat pour commencer",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -262,6 +262,8 @@ export type OrderPayload = {
   // For delivery orders
   customerName?: string;
   customerPhone?: string;
+  // Optional opt-in confirmation email (prefilled from Google sign-in when present)
+  customerEmail?: string;
   deliveryAddress?: string;
   deliveryCity?: string;
   deliveryFloor?: string;

--- a/services/api.ts
+++ b/services/api.ts
@@ -448,6 +448,7 @@ export async function createOrder(payload: OrderPayload): Promise<OrderResponse>
       table_number: payload.tableId,
       customer_name: payload.customerName,
       customer_phone: payload.customerPhone,
+      customer_email: payload.customerEmail || undefined,
       delivery_address: payload.deliveryAddress,
       delivery_city: payload.deliveryCity,
       delivery_floor: payload.deliveryFloor,


### PR DESCRIPTION
## Why

Lets customers who didn't sign in with Google still receive an order-confirmation email, by adding an optional email field at checkout. Pairs with the server PR that validates and sends it.

## Changes

- **`app/order/checkout/page.tsx`** — new optional email input below name/phone; `customerEmail` state prefilled from a Google sign-in (`guestAccount.email`) when present, and included in the order payload.
- **`services/api.ts`** — `createOrder` sends `customer_email`.
- **`lib/types.ts`** — `customerEmail?: string` on `OrderPayload`.
- **`lib/i18n.tsx`** — `emailOptional` helper text (en/he/fr).

The field is optional; leaving it blank keeps the existing phone-only flow. The server validates the address and falls back to the verified Google email when blank.

## Verification

`npx tsc --noEmit` and ESLint clean on the changed files.

https://claude.ai/code/session_017PzBd7XKWc68hTseYVPew8

---
_Generated by [Claude Code](https://claude.ai/code/session_017PzBd7XKWc68hTseYVPew8)_