### PR TITLE
Fix failing deploy: add saved-address fields to GuestAccount type

### DIFF
--- a/store/useGuestAccount.ts
+++ b/store/useGuestAccount.ts
@@ -9,6 +9,13 @@ export type GuestAccount = {
   name: string;
   picture?: string;
   phone?: string;
+  // Saved delivery address (set from past delivery orders / edited in the admin),
+  // used to autofill the checkout for returning signed-in guests.
+  address?: string;
+  city?: string;
+  floor?: string;
+  apt?: string;
+  delivery_notes?: string;
 };
 
 type GuestAccountState = {


### PR DESCRIPTION
## Why

The foodyweb CI / Vercel deploy has been failing since commit `e7f6ccb` (#70, "autofill saved delivery address") — **before** the recent email PRs. The `typecheck` job (`tsc --noEmit`) errors in `app/order/checkout/page.tsx`:

```
Property 'address' does not exist on type 'GuestAccount'
... 'city' ... 'floor' ... 'apt' ... 'delivery_notes'
```

The autofill code reads `guestAccount.address/city/floor/apt/delivery_notes`, but those fields were added only to the `GuestAuthAccount` **API** type (`services/api.ts`), not to the `GuestAccount` **store** type (`store/useGuestAccount.ts`) that the checkout actually consumes.

## Fix

Mirror the five optional saved-address fields onto `GuestAccount`. `npm run typecheck` and `npm run lint` now pass, unblocking the deploy.

## Note

This is a pre-existing break, not from the email work. (The earlier email PR's local check used a global `tsc` that bailed on a tsconfig deprecation before full type-checking and so didn't surface it; the project's `npm run typecheck` does.)

https://claude.ai/code/session_017PzBd7XKWc68hTseYVPew8

---
_Generated by [Claude Code](https://claude.ai/code/session_017PzBd7XKWc68hTseYVPew8)_