### PR TITLE
fix(web): show variant price range on item cards instead of ₪0.00

### DIFF
--- a/components/ItemModal.tsx
+++ b/components/ItemModal.tsx
@@ -8,7 +8,7 @@ import { useI18n } from "@/lib/i18n";
 import { useMenuLanguage } from "@/lib/menu-language";
 import { tField } from "@/lib/translations";
 import { modalPortionLabel } from "@/lib/portion";
-import { formatModifierLabel, modifiersDelta } from "@/lib/cart";
+import { effectiveOptionPrice, formatModifierLabel, modifiersDelta } from "@/lib/cart";
 import { VerbPalette } from "@/components/VerbPalette";
 import {
   enabledOperators,
@@ -266,8 +266,7 @@ export function ItemModal({ item, onClose, onAdd }: Props) {
       const selId = selectedVariants[os.id];
       const option = os.options.find((o) => o.id === selId);
       if (option) {
-        const raw = option.onlinePrice ?? option.price;
-        return raw > 0 ? raw : item.price;
+        return effectiveOptionPrice(item, option);
       }
     }
     return item.price;
@@ -281,9 +280,7 @@ export function ItemModal({ item, onClose, onAdd }: Props) {
       const selId = selectedVariants[os.id];
       const option = os.options.find((o) => o.id === selId);
       if (option) {
-        const raw = option.onlinePrice ?? option.price;
-        const effective = raw > 0 ? raw : item.price;
-        return { id: option.id, name: option.name, price: effective };
+        return { id: option.id, name: option.name, price: effectiveOptionPrice(item, option) };
       }
     }
     return undefined;

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -3,6 +3,7 @@ import { useI18n } from "@/lib/i18n";
 import { useMenuLanguage } from "@/lib/menu-language";
 import { tField } from "@/lib/translations";
 import { deriveItemPortion } from "@/lib/portion";
+import { itemDisplayPriceRange } from "@/lib/cart";
 import { roleTextStyle } from "@/lib/themes/typography";
 import clsx from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
@@ -52,6 +53,10 @@ export function MenuItemCard({
   const hasModifiers = item.modifiers && item.modifiers.length > 0;
   const isComboOnly = item.comboOnly === true;
   const isPicked = comboPickCount > 0;
+  // Items priced via size/variant options keep a 0 base price, so show the
+  // range derived from those options instead of a misleading ₪0.00.
+  const priceRange = itemDisplayPriceRange(item);
+  const hasPriceRange = priceRange.max > priceRange.min;
 
   return (
     <motion.button
@@ -215,7 +220,9 @@ export function MenuItemCard({
             </span>
           ) : (
             <span className="price" style={roleTextStyle("itemPrice", "1rem", "inherit", 700)}>
-              ₪{item.price.toFixed(2)}
+              {hasPriceRange
+                ? `₪${priceRange.min.toFixed(2)} – ₪${priceRange.max.toFixed(2)}`
+                : `₪${priceRange.min.toFixed(2)}`}
             </span>
           )}
 

--- a/components/themed/MenuItemCard/MenuItemCard.Compact.tsx
+++ b/components/themed/MenuItemCard/MenuItemCard.Compact.tsx
@@ -1,12 +1,14 @@
 import { useMenuLanguage } from "@/lib/menu-language";
 import { tField } from "@/lib/translations";
 import { roleTextStyle } from "@/lib/themes/typography";
+import { itemDisplayPriceRange } from "@/lib/cart";
 import type { MenuItemCardProps } from "./MenuItemCard";
 
 export function Compact({ item, currencySymbol, isMostPopular, onClick }: MenuItemCardProps) {
   const { menuLocale } = useMenuLanguage();
   const itemName = tField(item, "name", menuLocale);
   const itemDescription = tField(item, "description", menuLocale);
+  const priceRange = itemDisplayPriceRange(item);
   return (
     <button
       type="button"
@@ -26,7 +28,9 @@ export function Compact({ item, currencySymbol, isMostPopular, onClick }: MenuIt
             style={roleTextStyle("itemPrice", "1em", "display", 700)}
           >
             {currencySymbol}
-            {item.price.toFixed(2)}
+            {priceRange.min.toFixed(2)}
+            {priceRange.max > priceRange.min &&
+              ` – ${currencySymbol}${priceRange.max.toFixed(2)}`}
           </span>
         </div>
         {isMostPopular && (

--- a/components/themed/MenuItemCard/MenuItemCard.Magazine.tsx
+++ b/components/themed/MenuItemCard/MenuItemCard.Magazine.tsx
@@ -1,12 +1,14 @@
 import { useMenuLanguage } from "@/lib/menu-language";
 import { tField } from "@/lib/translations";
 import { roleTextStyle } from "@/lib/themes/typography";
+import { itemDisplayPriceRange } from "@/lib/cart";
 import type { MenuItemCardProps } from "./MenuItemCard";
 
 export function Magazine({ item, currencySymbol, isMostPopular, onClick }: MenuItemCardProps) {
   const { menuLocale } = useMenuLanguage();
   const itemName = tField(item, "name", menuLocale);
   const itemDescription = tField(item, "description", menuLocale);
+  const priceRange = itemDisplayPriceRange(item);
   return (
     <button
       type="button"
@@ -31,7 +33,9 @@ export function Magazine({ item, currencySymbol, isMostPopular, onClick }: MenuI
             style={roleTextStyle("itemPrice", "1.125rem", "display", 700)}
           >
             {currencySymbol}
-            {item.price.toFixed(2)}
+            {priceRange.min.toFixed(2)}
+            {priceRange.max > priceRange.min &&
+              ` – ${currencySymbol}${priceRange.max.toFixed(2)}`}
           </span>
         </div>
         {isMostPopular && (

--- a/lib/cart.ts
+++ b/lib/cart.ts
@@ -1,4 +1,4 @@
-import { CartLine, MenuItem, MenuItemModifier } from "@/lib/types";
+import { CartLine, MenuItem, MenuItemModifier, OptionSetOptionType } from "@/lib/types";
 import { tField } from "@/lib/translations";
 import type { Locale } from "@/lib/i18n";
 import {
@@ -48,24 +48,36 @@ export function modifiersDelta(modifiers?: MenuItemModifier[]) {
 }
 
 /**
+ * The price a single option contributes as the item's base when it is the
+ * selected variant. Online price wins when set (web shows online prices); an
+ * option price of 0 means "same as the item base" — a choice that doesn't
+ * change the price (e.g. a sauce on a pasta) — so it falls back to the item's
+ * own price. Single source of truth shared by the item card (price range) and
+ * the modal (selected-variant price); keep them resolving prices identically.
+ */
+export function effectiveOptionPrice(
+  item: MenuItem,
+  option: OptionSetOptionType,
+): number {
+  const raw = option.onlinePrice ?? option.price;
+  return raw > 0 ? raw : item.price;
+}
+
+/**
  * Effective price range shown on an item card. Items can carry their price on
  * size/variant options while the base `price` stays 0 (e.g. a salad sold only
  * as 250ml/500ml). The card would then read ₪0.00 even though the modal shows
  * real prices. Mirror the modal's pricing: the price-driving option set is the
- * first set that has options, and each option's effective price is
- * `onlinePrice ?? price`, falling back to the item base when that is 0. Returns
- * the min/max across that set so the card can render a single price or a range.
+ * first set that has options (the one whose default selection the modal uses
+ * for its base price), and each option resolves via {@link effectiveOptionPrice}.
+ * Returns the min/max across that set so the card can render a single price or
+ * a range. Falls back to the item base when there are no priced options.
  */
 export function itemDisplayPriceRange(item: MenuItem): { min: number; max: number } {
   const priceSet = (item.optionSets ?? []).find((os) => os.options.length > 0);
-  if (priceSet) {
-    const prices = priceSet.options.map((o) => {
-      const raw = o.onlinePrice ?? o.price;
-      return raw > 0 ? raw : item.price;
-    });
-    if (prices.length > 0) {
-      return { min: Math.min(...prices), max: Math.max(...prices) };
-    }
+  if (priceSet && priceSet.options.length > 0) {
+    const prices = priceSet.options.map((o) => effectiveOptionPrice(item, o));
+    return { min: Math.min(...prices), max: Math.max(...prices) };
   }
   return { min: item.price, max: item.price };
 }

--- a/lib/cart.ts
+++ b/lib/cart.ts
@@ -1,4 +1,4 @@
-import { CartLine, MenuItemModifier } from "@/lib/types";
+import { CartLine, MenuItem, MenuItemModifier } from "@/lib/types";
 import { tField } from "@/lib/translations";
 import type { Locale } from "@/lib/i18n";
 import {
@@ -45,6 +45,29 @@ export function modifiersDelta(modifiers?: MenuItemModifier[]) {
     }
   }
   return total;
+}
+
+/**
+ * Effective price range shown on an item card. Items can carry their price on
+ * size/variant options while the base `price` stays 0 (e.g. a salad sold only
+ * as 250ml/500ml). The card would then read ₪0.00 even though the modal shows
+ * real prices. Mirror the modal's pricing: the price-driving option set is the
+ * first set that has options, and each option's effective price is
+ * `onlinePrice ?? price`, falling back to the item base when that is 0. Returns
+ * the min/max across that set so the card can render a single price or a range.
+ */
+export function itemDisplayPriceRange(item: MenuItem): { min: number; max: number } {
+  const priceSet = (item.optionSets ?? []).find((os) => os.options.length > 0);
+  if (priceSet) {
+    const prices = priceSet.options.map((o) => {
+      const raw = o.onlinePrice ?? o.price;
+      return raw > 0 ? raw : item.price;
+    });
+    if (prices.length > 0) {
+      return { min: Math.min(...prices), max: Math.max(...prices) };
+    }
+  }
+  return { min: item.price, max: item.price };
 }
 
 export function lineUnitPrice(line: CartLine) {


### PR DESCRIPTION
## Problem

Items priced via size/variant options keep a `0` base price, so the menu cards rendered **₪0.00** even though the modal showed the real per-variant prices. Reproduced with "Les saveurs de Jacob" salads sold only as 250ml (₪15) / 500ml (₪25).

## Fix

- Added `itemDisplayPriceRange(item)` in `lib/cart.ts`, deriving min/max from the price-driving option set (the first set with options — the one whose default selection the modal already uses for its base price).
- Item cards now render a single price, or a range like `₪15.00 – ₪25.00` when variants differ — matching the admin's display.
- Extracted `effectiveOptionPrice()` as the single source of truth for resolving an option's price (`onlinePrice ?? price`, falling back to the item base when 0). The card range and the modal's base/variant price now resolve prices identically, so the rule can't drift.
- Applied the same fix to the themed `Compact`/`Magazine` cards (sandbox-only, but identical bug).

## Notes

- Inactive options, empty option sets, and combo-only variants are already filtered upstream in `services/api.ts`, so the range never sees bad data.
- The "first option set drives the price" assumption is shared with the modal by design (the card faithfully mirrors it rather than inventing divergent logic).

## Validation

- `npx tsc --noEmit` passes clean (only a pre-existing `baseUrl` deprecation warning).
- `next lint` not run — `node_modules` isn't installed in the session environment.

https://claude.ai/code/session_01XdF7S2YMNcV2biCWSnNbFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdF7S2YMNcV2biCWSnNbFH)_