### PR TITLE
Show item start price instead of full range on menu cards

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -53,10 +53,10 @@ export function MenuItemCard({
   const hasModifiers = item.modifiers && item.modifiers.length > 0;
   const isComboOnly = item.comboOnly === true;
   const isPicked = comboPickCount > 0;
-  // Items priced via size/variant options keep a 0 base price, so show the
-  // range derived from those options instead of a misleading ₪0.00.
+  // Items priced via size/variant options keep a 0 base price; derive the
+  // starting price from those options so the card shows ₪35 (not a misleading
+  // ₪0.00, and not the full range — just the entry price).
   const priceRange = itemDisplayPriceRange(item);
-  const hasPriceRange = priceRange.max > priceRange.min;
 
   return (
     <motion.button
@@ -220,9 +220,7 @@ export function MenuItemCard({
             </span>
           ) : (
             <span className="price" style={roleTextStyle("itemPrice", "1rem", "inherit", 700)}>
-              {hasPriceRange
-                ? `₪${priceRange.min.toFixed(2)} – ₪${priceRange.max.toFixed(2)}`
-                : `₪${priceRange.min.toFixed(2)}`}
+              {`₪${priceRange.min.toFixed(2)}`}
             </span>
           )}
 

--- a/components/themed/MenuItemCard/MenuItemCard.Compact.tsx
+++ b/components/themed/MenuItemCard/MenuItemCard.Compact.tsx
@@ -29,8 +29,6 @@ export function Compact({ item, currencySymbol, isMostPopular, onClick }: MenuIt
           >
             {currencySymbol}
             {priceRange.min.toFixed(2)}
-            {priceRange.max > priceRange.min &&
-              ` – ${currencySymbol}${priceRange.max.toFixed(2)}`}
           </span>
         </div>
         {isMostPopular && (

--- a/components/themed/MenuItemCard/MenuItemCard.Magazine.tsx
+++ b/components/themed/MenuItemCard/MenuItemCard.Magazine.tsx
@@ -34,8 +34,6 @@ export function Magazine({ item, currencySymbol, isMostPopular, onClick }: MenuI
           >
             {currencySymbol}
             {priceRange.min.toFixed(2)}
-            {priceRange.max > priceRange.min &&
-              ` – ${currencySymbol}${priceRange.max.toFixed(2)}`}
           </span>
         </div>
         {isMostPopular && (


### PR DESCRIPTION
## What

Menu item cards now show a single **starting price** (`₪35.00`) instead of the full **range** (`₪35.00 – ₪70.00`).

## Why

The range came from #73 ("show variant price range instead of ₪0.00"). That PR's real goal was to fix variant-priced items that displayed **₪0.00** because their price lives on the size options, not the base. Deriving the price from the option set already fixes that — `priceRange.min` is the real entry price (₪35), not 0. The full range was an unintended side effect that also hit items with a sensible base price.

This shows only `priceRange.min`, **keeping the ₪0.00 fix** while restoring the cleaner start-price display.

## Changes

- `MenuItemCard.tsx`, `MenuItemCard.Compact.tsx`, `MenuItemCard.Magazine.tsx` — render `priceRange.min` only; drop the now-unused `hasPriceRange`.

## Validation

- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (only pre-existing `<img>` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013WSatyVGTzpWk3A2n8C9i3)_