### PR TITLE
Promote: checkout out-of-stock gating + delivery-zone block

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -199,13 +199,18 @@ function CheckoutContent() {
     }
     return map;
   }, [freshMenu]);
+  // Scheduled and batch-fulfillment orders target a future date, so today's sold-out
+  // state isn't the right gate — mirror the mutation, which skips the real-time check
+  // for them. Leave the per-line map empty so nothing is flagged or blocked.
+  const availabilityCheckEnabled = !isScheduled && !restaurant?.batchFulfillmentEnabled;
   const lineAvailability = useMemo(() => {
     const map = new Map<string, LineAvailability>();
-    for (const line of displayLines) {
+    if (!hydrated || !availabilityCheckEnabled) return map;
+    for (const line of lines) {
       map.set(line.id, computeLineAvailability(line, availabilityMap));
     }
     return map;
-  }, [displayLines, availabilityMap]);
+  }, [hydrated, lines, availabilityMap, availabilityCheckEnabled]);
   const hasBlockedLines = useMemo(
     () => Array.from(lineAvailability.values()).some((s) => s.status !== "ok"),
     [lineAvailability]
@@ -1405,11 +1410,21 @@ function CheckoutContent() {
                   </p>
                 )}
 
+                {hasBlockedLines && (
+                  <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-xl">
+                    <span className="text-xl">⚠️</span>
+                    <div className="flex-1">
+                      <p className="text-sm font-semibold text-amber-800">{t("itemsUnavailableTitle")}</p>
+                      <p className="text-sm text-amber-700">{t("itemsUnavailableHelp")}</p>
+                    </div>
+                  </div>
+                )}
+
                 <button
                   type="button"
                   onClick={handleConfirmOrder}
-                  disabled={createOrderMutation.isPending || isBelowMinimum || (orderType === 'delivery' && zoneStatus === 'blocked')}
-                  className="w-full py-4 rounded-xl bg-brand text-white font-bold shadow-lg shadow-brand/30 hover:bg-brand-dark transition disabled:opacity-50"
+                  disabled={createOrderMutation.isPending || checkoutBlocked || (orderType === 'delivery' && zoneStatus === 'blocked')}
+                  className="w-full py-4 rounded-xl bg-brand text-white font-bold shadow-lg shadow-brand/30 hover:bg-brand-dark transition disabled:bg-[var(--surface-subtle)] disabled:text-[var(--text-muted)] disabled:shadow-none disabled:cursor-not-allowed"
                 >
                   {createOrderMutation.isPending
                     ? "..."
@@ -1428,7 +1443,10 @@ function CheckoutContent() {
                     : t("confirmAndPay") || t("confirmOrder")}
                 </button>
 
-                {createOrderMutation.isError && (
+                {/* Availability rejections surface through the amber banner + per-line
+                    actions above (onError refetches), so only show the raw message for
+                    other failures (closed, paused, payment, etc.). */}
+                {createOrderMutation.isError && !hasBlockedLines && (
                   <p className="text-sm text-red-500 text-center">
                     {(createOrderMutation.error as any)?.message || t("failedToCreateOrder")}
                   </p>

--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -4,13 +4,14 @@ import { Suspense } from "react";
 import { useCartStore } from "@/store/useCartStore";
 import { useI18n } from "@/lib/i18n";
 import { useHydrated } from "@/hooks/useHydrated";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
 import {
   createOrder,
+  fetchMenu,
   sendOTP,
   verifyOTP,
   fetchRestaurant,
@@ -18,9 +19,11 @@ import {
   fetchBatchFulfillmentConfig,
   checkTrustedCustomer,
   fetchMe,
+  checkDeliveryAddress,
 } from "@/services/api";
 import { BatchFulfillmentConfigResponse, CheckoutConfig, OrderPayload, OrderType, Restaurant, SchedulingConfigResponse, SchedulingTimeSlot } from "@/lib/types";
 import { formatModifierLabel, lineTotal, lineUnitPrice } from "@/lib/cart";
+import { computeLineAvailability, type ItemAvailability, type LineAvailability } from "@/lib/cart-availability";
 import { tField } from "@/lib/translations";
 import { useMenuLanguage } from "@/lib/menu-language";
 import { checkAvailability } from "@/lib/availability";
@@ -108,6 +111,8 @@ function CheckoutContent() {
   const total = useCartStore((s) => s.total);
   const currency = useCartStore((s) => s.currency);
   const clear = useCartStore((s) => s.clear);
+  const removeItem = useCartStore((s) => s.removeItem);
+  const updateQuantity = useCartStore((s) => s.updateQuantity);
 
   // Restaurant data
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
@@ -125,6 +130,12 @@ function CheckoutContent() {
   const [deliveryNotes, setDeliveryNotes] = useState("");
   const [pickupNotes, setPickupNotes] = useState("");
   const [deliveryLatLng, setDeliveryLatLng] = useState<{ lat: number; lng: number } | null>(null);
+
+  // Delivery zone check state
+  type ZoneStatus = 'idle' | 'checking' | 'ok' | 'blocked';
+  const [zoneStatus, setZoneStatus] = useState<ZoneStatus>('idle');
+  const [zoneReason, setZoneReason] = useState<string>('');
+
   // Values for owner-defined custom fields, keyed by field id. Empty when the
   // restaurant is on the legacy hard-coded checkout (or has no custom fields).
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, string | boolean>>({});
@@ -168,6 +179,38 @@ function CheckoutContent() {
   // Minimum order check for delivery
   const minimumOrderDelivery = restaurant?.minimumOrderDelivery ?? 0;
   const isBelowMinimum = orderType === "delivery" && minimumOrderDelivery > 0 && displayTotal < minimumOrderDelivery;
+
+  // Fresh availability — re-checked at checkout so an item that sold out since being
+  // added to the cart is caught before the customer pays, not only by the server guard.
+  const { data: freshMenu, refetch: refetchAvailability } = useQuery({
+    queryKey: ["checkout-availability", restaurantId],
+    queryFn: () => fetchMenu(restaurantId),
+    enabled: !!restaurantId,
+    staleTime: 0,
+  });
+  const availabilityMap = useMemo(() => {
+    const map = new Map<string, ItemAvailability>();
+    for (const item of freshMenu?.items ?? []) {
+      map.set(item.id, {
+        state: item.availabilityState,
+        buildableCount: item.buildableCount,
+        available: item.available,
+      });
+    }
+    return map;
+  }, [freshMenu]);
+  const lineAvailability = useMemo(() => {
+    const map = new Map<string, LineAvailability>();
+    for (const line of displayLines) {
+      map.set(line.id, computeLineAvailability(line, availabilityMap));
+    }
+    return map;
+  }, [displayLines, availabilityMap]);
+  const hasBlockedLines = useMemo(
+    () => Array.from(lineAvailability.values()).some((s) => s.status !== "ok"),
+    [lineAvailability]
+  );
+  const checkoutBlocked = hasBlockedLines || isBelowMinimum;
 
   // Normalize phone number with country code
   const normalizePhone = (phone: string) => {
@@ -311,6 +354,34 @@ function CheckoutContent() {
       .then(setBatchConfig)
       .catch(console.error);
   }, [restaurant?.batchFulfillmentEnabled, restaurantId]);
+
+  // Delivery zone check: fires after address is entered/geocoded, debounced 500ms.
+  // Only runs for delivery orders. On network error, falls back to idle so the
+  // server guard (not the UI) rejects truly out-of-zone orders.
+  useEffect(() => {
+    if (orderType !== 'delivery') { setZoneStatus('idle'); return; }
+    const hasCoord = !!deliveryLatLng;
+    const hasText = deliveryAddress.trim() !== '' || deliveryCity.trim() !== '';
+    if (!hasCoord && !hasText) { setZoneStatus('idle'); return; }
+    setZoneStatus('checking');
+    const handle = setTimeout(async () => {
+      try {
+        const r = await checkDeliveryAddress({
+          restaurantId,
+          lat: deliveryLatLng?.lat,
+          lng: deliveryLatLng?.lng,
+          address: deliveryAddress || undefined,
+          city: deliveryCity || undefined,
+        });
+        if (r.deliverable) { setZoneStatus('ok'); setZoneReason(''); }
+        else { setZoneStatus('blocked'); setZoneReason(r.reason); }
+      } catch {
+        // Network/API error: do not hard-block — server guard still rejects out-of-zone orders.
+        setZoneStatus('idle');
+      }
+    }, 500);
+    return () => clearTimeout(handle);
+  }, [orderType, deliveryLatLng, deliveryAddress, deliveryCity, restaurantId]);
 
   // Send OTP mutation
   const sendOtpMutation = useMutation({
@@ -482,6 +553,12 @@ function CheckoutContent() {
         const qs = `?restaurantId=${restaurantId}${tableId ? `&tableId=${tableId}` : ""}${sessionId ? `&sessionId=${sessionId}` : ""}`;
         router.push(`/order/confirmation/${data.orderId}${qs}`);
       }
+    },
+    onError: () => {
+      // A rejection here is usually the server availability guard catching an item
+      // that sold out between our last check and submit. Re-fetch so the proactive
+      // per-line UI lights up and the customer can fix the offending line.
+      refetchAvailability();
     },
   });
 
@@ -1209,11 +1286,24 @@ function CheckoutContent() {
 
                 {/* Order Items */}
                 <div className="space-y-3 max-h-64 overflow-y-auto">
-                  {displayLines.map((line) => (
-                    <div key={line.id} className="flex items-start gap-3 py-2 border-b border-[var(--divider)] last:border-0">
+                  {displayLines.map((line) => {
+                    const status = lineAvailability.get(line.id) ?? { status: "ok" as const };
+                    const blocked = status.status !== "ok";
+                    return (
+                    <div key={line.id} className={`flex items-start gap-3 py-2 border-b border-[var(--divider)] last:border-0${blocked ? " opacity-60" : ""}`}>
                       <div className="flex-1">
                         <p className="font-medium">
                           {tField(line.item, "name", menuLocale)}{line.selectedVariantName ? ` - ${line.selectedVariantName}` : ''}
+                          {status.status === "sold_out" && (
+                            <span className="ml-2 align-middle text-[10px] font-semibold px-2 py-0.5 rounded-full bg-red-100 text-red-700">
+                              {t("soldOut")}
+                            </span>
+                          )}
+                          {status.status === "insufficient" && (
+                            <span className="ml-2 align-middle text-[10px] font-semibold px-2 py-0.5 rounded-full bg-amber-100 text-amber-800">
+                              {status.available} {t("left")}
+                            </span>
+                          )}
                         </p>
                         {line.modifiers && line.modifiers.length > 0 && (
                           <div className="mt-1 flex flex-wrap gap-1">
@@ -1228,13 +1318,32 @@ function CheckoutContent() {
                           </div>
                         )}
                         {line.note && <p className="text-xs text-[var(--text-muted)] mt-1">{line.note}</p>}
+                        {status.status === "sold_out" && (
+                          <button
+                            type="button"
+                            onClick={() => removeItem(line.id)}
+                            className="mt-1 text-xs font-semibold text-red-600 hover:underline"
+                          >
+                            {t("remove")}
+                          </button>
+                        )}
+                        {status.status === "insufficient" && (
+                          <button
+                            type="button"
+                            onClick={() => updateQuantity(line.id, status.available)}
+                            className="mt-1 text-xs font-semibold text-amber-700 hover:underline"
+                          >
+                            {t("reduceToN").replace("{n}", String(status.available))}
+                          </button>
+                        )}
                       </div>
                       <div className="text-right">
                         <p className="font-medium">{currency} {lineTotal(line).toFixed(2)}</p>
                         <p className="text-xs text-[var(--text-muted)]">×{line.quantity}</p>
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
 
                 {/* Total with VAT Breakdown */}
@@ -1288,10 +1397,18 @@ function CheckoutContent() {
                   </div>
                 )}
 
+                {orderType === 'delivery' && zoneStatus === 'blocked' && (
+                  <p className="text-sm text-red-500 text-center">
+                    {zoneReason === 'address_unresolved'
+                      ? (t('deliveryRefineAddress') || 'Please enter a more specific address.')
+                      : (t('deliveryOutsideZone') || "Sorry, we don't deliver to this address yet.")}
+                  </p>
+                )}
+
                 <button
                   type="button"
                   onClick={handleConfirmOrder}
-                  disabled={createOrderMutation.isPending || isBelowMinimum}
+                  disabled={createOrderMutation.isPending || isBelowMinimum || (orderType === 'delivery' && zoneStatus === 'blocked')}
                   className="w-full py-4 rounded-xl bg-brand text-white font-bold shadow-lg shadow-brand/30 hover:bg-brand-dark transition disabled:opacity-50"
                 >
                   {createOrderMutation.isPending

--- a/docs/superpowers/specs/2026-06-22-checkout-availability-design.md
+++ b/docs/superpowers/specs/2026-06-22-checkout-availability-design.md
@@ -69,6 +69,11 @@ Map<string /* itemId */, { state?: AvailabilityState; buildableCount?: number | 
 Refetched on mount and again on a failed submit (so a race-condition rejection lights up
 the proactive UI).
 
+**Scheduled / batch orders are exempt.** They target a future fulfilment date, so today's
+sold-out state is the wrong gate — the order mutation already skips the real-time check for
+them. The proactive check follows suit (`availabilityCheckEnabled = !isScheduled &&
+!restaurant.batchFulfillmentEnabled`): the per-line map stays empty, nothing is flagged.
+
 ## Pure Helper — `lib/cart-availability.ts`
 
 Keeps the 1300-line page thin and gives the logic a unit test (matches the existing
@@ -149,16 +154,14 @@ and the reactive path just re-triggers it.
 
 | key | en | he | fr |
 |---|---|---|---|
-| `onlyNLeft` | `Only {n} left` | `נשארו {n}` | `Plus que {n}` |
+| `remove` | `Remove` | `הסר` | `Retirer` |
 | `reduceToN` | `Reduce to {n}` | `הפחת ל-{n}` | `Réduire à {n}` |
-| `removeItem` | `Remove` | `הסר` | `Retirer` |
 | `itemsUnavailableTitle` | `Some items are no longer available` | `חלק מהפריטים אינם זמינים יותר` | `Certains articles ne sont plus disponibles` |
 | `itemsUnavailableHelp` | `Adjust the highlighted items to continue.` | `עדכן את הפריטים המסומנים כדי להמשיך.` | `Ajustez les articles en surbrillance pour continuer.` |
 
-The reactive fallback reuses `itemsUnavailableTitle` (no separate key needed).
-
-Reuse existing `soldOut`. (Hebrew strings to be confirmed during review; placeholders above
-follow the existing translation tone.)
+The insufficient-stock badge reuses the existing `left` key (`{n} {t("left")}`, already used by
+`MenuItemCard`), and the sold-out badge reuses existing `soldOut`. The reactive fallback reuses
+`itemsUnavailableTitle` (no separate key needed). Hebrew strings to be confirmed during review.
 
 ## Limitations (this iteration)
 

--- a/docs/superpowers/specs/2026-06-22-checkout-availability-design.md
+++ b/docs/superpowers/specs/2026-06-22-checkout-availability-design.md
@@ -1,0 +1,186 @@
+# foodyweb Checkout — Out-of-Stock & Minimum-Order Gating
+
+**Date:** 2026-06-22
+**Service:** foodyweb only (no foodyserver / foodypos changes)
+**Status:** Design approved, pending spec review
+
+## Problem
+
+On the checkout/payment page (`app/order/checkout/page.tsx`), when an item in the
+cart has gone out of stock between adding it and reaching payment, the only signal
+is the raw server rejection rendered as small red text below the pay button:
+
+> `only 0 of "L'OR ROUGE" available right now`
+
+Three problems with this:
+
+1. **Untranslated** — the server string is English even on a French (or Hebrew) page.
+2. **Detached from the item** — the message sits at the bottom of the summary while the
+   offending line is at the top of a multi-item list; the customer cannot tell which item.
+3. **Reactive only** — the orange "Commander et payer" button stays fully active, so the
+   customer taps into a guaranteed failure instead of being stopped beforehand.
+
+A related inconsistency: the **minimum-order** case for delivery *already* disables the
+button (`disabled={... || isBelowMinimum}`) and shows an amber banner, but the disabled
+styling (`disabled:opacity-50`) keeps the button orange and looking tappable. We want both
+gating reasons — out-of-stock and below-minimum — to read as clearly blocked, consistently.
+
+## Goals
+
+- Catch out-of-stock items **proactively**, before the customer taps pay.
+- Tie the message to the **specific cart line**, translated (fr/he/en).
+- Offer a **one-tap fix** per line: remove a sold-out item, or reduce quantity to the
+  available count when only partial stock remains.
+- Disable the pay button while **any** blocking condition holds (out-of-stock OR
+  below-minimum), with a genuinely-disabled visual.
+- Keep the server availability guard as the final safety net, but replace its raw English
+  rejection with a translated fallback banner.
+
+## Non-Goals
+
+- No foodyserver or foodypos changes; no new/changed API contract.
+- Combo lines are **not** proactively stock-checked in this iteration (see Limitations).
+- Variant-level (per-size) availability precision is not attempted client-side; the check
+  is item-level. The server guard remains authoritative for variant edge cases.
+
+## Data Source
+
+Checkout is a client component that today reads only the Zustand cart store. The menu (with
+per-item `availabilityState` and `buildableCount`) is fetched server-side on the order page,
+so there is no client cache to reuse here.
+
+Add a client query on the checkout page:
+
+```ts
+const { data: freshMenu, refetch: refetchAvailability } = useQuery({
+  queryKey: ["checkout-availability", restaurantId],
+  queryFn: () => fetchMenu(restaurantId),
+  enabled: !!restaurantId,
+});
+```
+
+`fetchMenu` already uses `cache: "no-store"`, so each fetch is current. From the result,
+build a flat lookup of every item across all menus/groups:
+
+```ts
+Map<string /* itemId */, { state?: AvailabilityState; buildableCount?: number | null }>
+```
+
+Refetched on mount and again on a failed submit (so a race-condition rejection lights up
+the proactive UI).
+
+## Pure Helper — `lib/cart-availability.ts`
+
+Keeps the 1300-line page thin and gives the logic a unit test (matches the existing
+`lib/__tests__/*.test.ts` pattern run by `node --test`).
+
+```ts
+export type LineAvailability =
+  | { status: "ok" }
+  | { status: "sold_out" }
+  | { status: "insufficient"; available: number }; // available >= 1, < requested qty
+
+export function computeLineAvailability(
+  line: CartLine,
+  availability: Map<string, { state?: AvailabilityState; buildableCount?: number | null }>,
+): LineAvailability;
+```
+
+Rules for a non-combo line:
+
+1. Combo line (`line.comboId` set) → `ok` (out of scope this iteration).
+2. No entry in the map (item vanished from menu) → `ok` (let the server guard decide).
+3. `state === "sold_out"` or the item is otherwise unavailable → `sold_out`.
+4. `buildableCount != null && buildableCount < line.quantity`:
+   - `buildableCount <= 0` → `sold_out`
+   - else → `insufficient` with `available = buildableCount`
+5. Otherwise → `ok`.
+
+Derived in the page:
+
+```ts
+const lineStatus = new Map(displayLines.map((l) => [l.id, computeLineAvailability(l, availMap)]));
+const hasBlockedLines = [...lineStatus.values()].some((s) => s.status !== "ok");
+const checkoutBlocked = hasBlockedLines || isBelowMinimum;
+```
+
+## UI Changes (order summary, `app/order/checkout/page.tsx`)
+
+### 1. Per-line indicator + action (line ~1212 list)
+
+For a line whose status is not `ok`:
+
+- Dim the line (`opacity-60`) and append a badge after the name:
+  - `sold_out` → red badge, `t("soldOut")` ("Épuisé").
+  - `insufficient` → amber badge, `t("onlyNLeft").replace("{n}", available)` ("Plus que {n}").
+- A small action button under the line:
+  - `sold_out` → `t("removeItem")` ("Retirer") → `removeItem(line.id)`.
+  - `insufficient` → `t("reduceToN").replace("{n}", available)` ("Réduire à {n}")
+    → `updateQuantity(line.id, available)`.
+
+Cart store already exposes `removeItem(lineId)` and `updateQuantity(lineId, qty)`.
+
+### 2. Blocking banner above the pay button
+
+When `hasBlockedLines`, show an amber/red info box (same visual family as the existing
+minimum-order banner) with `t("itemsUnavailableTitle")` and `t("itemsUnavailableHelp")`.
+The existing minimum-order banner (line ~1196) stays as-is.
+
+### 3. Pay button (line ~1291)
+
+- `disabled={createOrderMutation.isPending || checkoutBlocked}`.
+- Replace the weak `disabled:opacity-50` with a clearly-disabled style: grey background,
+  no brand shadow, `disabled:cursor-not-allowed` — so both gating reasons look non-clickable.
+
+### 4. Reactive fallback (line ~1314)
+
+On `createOrderMutation.isError`, call `refetchAvailability()`, then decide the message
+purely from the refetched state (no fragile parsing of the English server string):
+
+- If `hasBlockedLines` is now true (the refetch surfaced the sold-out item) → show the
+  translated `t("itemsUnavailableTitle")` banner; the per-line badges/actions are already lit.
+- Otherwise (a different rejection — closed, paused, payment, etc.) → keep showing
+  `error.message` as today. Those errors already have their own copy and are out of scope.
+
+This means we never try to map the raw string to a line; the proactive path does the mapping
+and the reactive path just re-triggers it.
+
+## i18n — new keys (`lib/i18n.tsx`, en/he/fr)
+
+| key | en | he | fr |
+|---|---|---|---|
+| `onlyNLeft` | `Only {n} left` | `נשארו {n}` | `Plus que {n}` |
+| `reduceToN` | `Reduce to {n}` | `הפחת ל-{n}` | `Réduire à {n}` |
+| `removeItem` | `Remove` | `הסר` | `Retirer` |
+| `itemsUnavailableTitle` | `Some items are no longer available` | `חלק מהפריטים אינם זמינים יותר` | `Certains articles ne sont plus disponibles` |
+| `itemsUnavailableHelp` | `Adjust the highlighted items to continue.` | `עדכן את הפריטים המסומנים כדי להמשיך.` | `Ajustez les articles en surbrillance pour continuer.` |
+
+The reactive fallback reuses `itemsUnavailableTitle` (no separate key needed).
+
+Reuse existing `soldOut`. (Hebrew strings to be confirmed during review; placeholders above
+follow the existing translation tone.)
+
+## Limitations (this iteration)
+
+- **Combos** are not proactively checked — a combo whose underlying item is sold out will
+  still rely on the server guard + translated fallback banner. Acceptable: combos are a small
+  fraction of carts and per-step resolution is a larger task.
+- **Variant precision** — item-level check only; a sold-out *specific size* of an otherwise
+  available item may pass the proactive check and be caught by the server guard.
+
+## Testing
+
+- Unit test `lib/__tests__/cart-availability.test.ts` for `computeLineAvailability`: ok,
+  sold_out (state), sold_out (buildableCount<=0), insufficient (1 <= count < qty), combo
+  line passthrough, missing-entry passthrough.
+- `npm run lint && npx tsc --noEmit` for the page/i18n changes.
+- Manual: a cart with one sold-out and one low-stock item → both flagged, button disabled,
+  remove/reduce actions clear the block; delivery below minimum → button disabled with banner.
+
+## Files Touched
+
+- `app/order/checkout/page.tsx` — availability query, derived status, per-line UI, banner,
+  button disable + style, reactive fallback.
+- `lib/cart-availability.ts` — new pure helper.
+- `lib/__tests__/cart-availability.test.ts` — new unit test.
+- `lib/i18n.tsx` — new keys (en/he/fr).

--- a/lib/__tests__/cart-availability.test.ts
+++ b/lib/__tests__/cart-availability.test.ts
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeLineAvailability, type ItemAvailability } from "../cart-availability";
+import type { CartLine, MenuItem } from "../types";
+
+function menuItem(partial: Partial<MenuItem> = {}): MenuItem {
+  return { id: "1", name: "Test", price: 0, groupId: "g1", ...partial };
+}
+
+function line(partial: Partial<CartLine> = {}): CartLine {
+  return { id: "l1", item: menuItem(), quantity: 1, ...partial };
+}
+
+function availMap(entries: Array<[string, ItemAvailability]>): Map<string, ItemAvailability> {
+  return new Map(entries);
+}
+
+test("available item with enough stock is ok", () => {
+  const result = computeLineAvailability(
+    line({ quantity: 2 }),
+    availMap([["1", { state: "available" }]]),
+  );
+  assert.deepEqual(result, { status: "ok" });
+});
+
+test("sold_out state blocks the line", () => {
+  const result = computeLineAvailability(
+    line(),
+    availMap([["1", { state: "sold_out" }]]),
+  );
+  assert.deepEqual(result, { status: "sold_out" });
+});
+
+test("available === false is treated as sold_out", () => {
+  const result = computeLineAvailability(
+    line(),
+    availMap([["1", { available: false }]]),
+  );
+  assert.deepEqual(result, { status: "sold_out" });
+});
+
+test("buildableCount of 0 blocks the line as sold_out", () => {
+  const result = computeLineAvailability(
+    line({ quantity: 2 }),
+    availMap([["1", { state: "low", buildableCount: 0 }]]),
+  );
+  assert.deepEqual(result, { status: "sold_out" });
+});
+
+test("buildableCount below requested quantity is insufficient with the available count", () => {
+  const result = computeLineAvailability(
+    line({ quantity: 3 }),
+    availMap([["1", { state: "low", buildableCount: 2 }]]),
+  );
+  assert.deepEqual(result, { status: "insufficient", available: 2 });
+});
+
+test("buildableCount at or above requested quantity is ok", () => {
+  const result = computeLineAvailability(
+    line({ quantity: 3 }),
+    availMap([["1", { state: "low", buildableCount: 5 }]]),
+  );
+  assert.deepEqual(result, { status: "ok" });
+});
+
+test("low state with no buildableCount is ok", () => {
+  const result = computeLineAvailability(
+    line({ quantity: 4 }),
+    availMap([["1", { state: "low", buildableCount: null }]]),
+  );
+  assert.deepEqual(result, { status: "ok" });
+});
+
+test("combo lines are not proactively checked (server guard is the safety net)", () => {
+  const result = computeLineAvailability(
+    line({ comboId: 42, item: menuItem({ id: "combo-42" }) }),
+    availMap([["combo-42", { state: "sold_out" }]]),
+  );
+  assert.deepEqual(result, { status: "ok" });
+});
+
+test("item missing from the fresh menu passes through as ok", () => {
+  const result = computeLineAvailability(line(), availMap([]));
+  assert.deepEqual(result, { status: "ok" });
+});

--- a/lib/cart-availability.ts
+++ b/lib/cart-availability.ts
@@ -1,0 +1,52 @@
+import type { CartLine } from "./types";
+
+/** Recipe-aware availability for a single item, as exposed by the public menu API
+ *  (`availabilityState` + `buildableCount`). `available === false` mirrors the
+ *  legacy `is_active` flag and is treated the same as a sold-out state. */
+export type ItemAvailability = {
+  state?: "available" | "low" | "sold_out" | "hidden";
+  buildableCount?: number | null;
+  available?: boolean;
+};
+
+/** Result of cross-checking one cart line against fresh menu availability.
+ *  `insufficient.available` is always >= 1 and strictly below the requested quantity. */
+export type LineAvailability =
+  | { status: "ok" }
+  | { status: "sold_out" }
+  | { status: "insufficient"; available: number };
+
+/**
+ * Classifies a cart line against the restaurant's current item availability so the
+ * checkout can flag (and offer to fix) lines that can no longer be fulfilled.
+ *
+ * Combo lines and items absent from the fresh menu pass through as `ok` — the
+ * server-side availability guard remains the authoritative safety net for those.
+ *
+ * @param line The cart line to check.
+ * @param availability Map of item id → current availability, built from `fetchMenu`.
+ */
+export function computeLineAvailability(
+  line: CartLine,
+  availability: Map<string, ItemAvailability>,
+): LineAvailability {
+  // Combos resolve their stock across multiple step items; the server guard owns
+  // that case. Don't half-check it here.
+  if (line.comboId != null) return { status: "ok" };
+
+  const info = availability.get(line.item.id);
+  // Item vanished from the menu between adding and checkout — let the server decide.
+  if (!info) return { status: "ok" };
+
+  if (info.available === false || info.state === "sold_out" || info.state === "hidden") {
+    return { status: "sold_out" };
+  }
+
+  const count = info.buildableCount;
+  if (count != null && count < line.quantity) {
+    if (count <= 0) return { status: "sold_out" };
+    return { status: "insufficient", available: count };
+  }
+
+  return { status: "ok" };
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -12,6 +12,10 @@ const translations: Record<Locale, Record<string, string>> = {
     soldOut: "Sold out",
     lowStock: "Low stock",
     left: "left",
+    remove: "Remove",
+    reduceToN: "Reduce to {n}",
+    itemsUnavailableTitle: "Some items are no longer available",
+    itemsUnavailableHelp: "Adjust the highlighted items to continue.",
     cart: "Cart",
     yourOrder: "Your order",
     estimatedServiceFee: "Estimated service fee",
@@ -450,7 +454,10 @@ const translations: Record<Locale, Record<string, string>> = {
     each: "each",
     free: "Free",
     includedFree: "included",
-    orders: "orders"
+    orders: "orders",
+    // Delivery zone check
+    deliveryOutsideZone: "Sorry, we don't deliver to this address yet.",
+    deliveryRefineAddress: "Please enter a more specific address.",
   },
   he: {
     all: "הכל",
@@ -459,6 +466,10 @@ const translations: Record<Locale, Record<string, string>> = {
     soldOut: "אזל",
     lowStock: "מלאי נמוך",
     left: "נותרו",
+    remove: "הסר",
+    reduceToN: "הפחת ל-{n}",
+    itemsUnavailableTitle: "חלק מהפריטים אינם זמינים יותר",
+    itemsUnavailableHelp: "עדכן את הפריטים המסומנים כדי להמשיך.",
     cart: "עגלת קניות",
     yourOrder: "ההזמנה שלך",
     estimatedServiceFee: "דמי שירות משוערים",
@@ -897,7 +908,10 @@ const translations: Record<Locale, Record<string, string>> = {
     each: "כל אחד",
     free: "חינם",
     includedFree: "כלולים",
-    orders: "הזמנות"
+    orders: "הזמנות",
+    // Delivery zone check
+    deliveryOutsideZone: "מצטערים, איננו מבצעים משלוחים לכתובת זו עדיין.",
+    deliveryRefineAddress: "אנא הזינו כתובת מדויקת יותר.",
   },
   fr: {
     all: "Tout",
@@ -906,6 +920,10 @@ const translations: Record<Locale, Record<string, string>> = {
     soldOut: "Épuisé",
     lowStock: "Stock faible",
     left: "restant",
+    remove: "Retirer",
+    reduceToN: "Réduire à {n}",
+    itemsUnavailableTitle: "Certains articles ne sont plus disponibles",
+    itemsUnavailableHelp: "Ajustez les articles en surbrillance pour continuer.",
     cart: "Panier",
     yourOrder: "Votre commande",
     estimatedServiceFee: "Frais de service estimés",
@@ -1344,7 +1362,10 @@ const translations: Record<Locale, Record<string, string>> = {
     each: "chacun",
     free: "Gratuit",
     includedFree: "inclus",
-    orders: "commandes"
+    orders: "commandes",
+    // Delivery zone check
+    deliveryOutsideZone: "Desole, nous ne livrons pas encore a cette adresse.",
+    deliveryRefineAddress: "Veuillez saisir une adresse plus precise.",
   }
 };
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -1053,3 +1053,34 @@ export async function fetchCourierTracking(
   };
 }
 
+// ============ Delivery Zone Check ============
+
+/**
+ * Check whether a given address/coordinates falls within the restaurant's
+ * configured delivery zone. Returns `deliverable` (in zone), `resolved`
+ * (server was able to resolve the zone), and `reason` (human-readable
+ * explanation for why delivery is or is not available).
+ *
+ * Supply `lat`/`lng` when the caller has already geocoded the address
+ * (e.g. from Google Places Autocomplete). Supply `address`/`city` as text
+ * fallback — the server will geocode internally. At least one of the two
+ * forms should be provided.
+ */
+export async function checkDeliveryAddress(params: {
+  restaurantId: string;
+  lat?: number;
+  lng?: number;
+  address?: string;
+  city?: string;
+}): Promise<{ deliverable: boolean; resolved: boolean; reason: string }> {
+  const q = new URLSearchParams({ restaurant_id: params.restaurantId });
+  if (params.lat != null && params.lng != null) {
+    q.set('lat', String(params.lat));
+    q.set('lng', String(params.lng));
+  }
+  if (params.address) q.set('address', params.address);
+  if (params.city) q.set('city', params.city);
+  const res = await fetch(`${PUBLIC_PREFIX}/delivery/check?${q.toString()}`);
+  return handleResponse<{ deliverable: boolean; resolved: boolean; reason: string }>(res);
+}
+


### PR DESCRIPTION
Promotes develop → main (production).

## Shipping in this promote
- **feat(checkout): proactive out-of-stock gating + minimum-order button disable** — cross-checks cart lines against fresh menu availability at checkout; flags sold-out / insufficient-stock lines inline with one-tap remove / reduce-to-N, shows a translated banner, disables the pay button while any line is blocked or the delivery minimum is unmet, and replaces the raw English server-error string with a translated fallback. Scheduled / batch orders exempt. Pure helper with unit tests. (foodyweb-only)
- **feat(delivery): block out-of-zone delivery addresses at checkout** + delivery-zone client (concurrent work already on develop)
- docs: checkout availability design spec

## Validation
- CI green on develop HEAD: Lint & Type Check ✓, Build ✓, Deploy Dev ✓
- `npx tsc --noEmit` clean · `npm run lint` clean on changed files · 34/34 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)