### PR TITLE
Promote develop → main: delivery-zone checkout enforcement

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -369,6 +369,7 @@ function CheckoutContent() {
     const hasText = deliveryAddress.trim() !== '' || deliveryCity.trim() !== '';
     if (!hasCoord && !hasText) { setZoneStatus('idle'); return; }
     setZoneStatus('checking');
+    let cancelled = false;
     const handle = setTimeout(async () => {
       try {
         const r = await checkDeliveryAddress({
@@ -378,14 +379,17 @@ function CheckoutContent() {
           address: deliveryAddress || undefined,
           city: deliveryCity || undefined,
         });
+        // Ignore a stale response if the address changed while this was in flight.
+        if (cancelled) return;
         if (r.deliverable) { setZoneStatus('ok'); setZoneReason(''); }
         else { setZoneStatus('blocked'); setZoneReason(r.reason); }
       } catch {
         // Network/API error: do not hard-block — server guard still rejects out-of-zone orders.
+        if (cancelled) return;
         setZoneStatus('idle');
       }
     }, 500);
-    return () => clearTimeout(handle);
+    return () => { cancelled = true; clearTimeout(handle); };
   }, [orderType, deliveryLatLng, deliveryAddress, deliveryCity, restaurantId]);
 
   // Send OTP mutation

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1364,8 +1364,8 @@ const translations: Record<Locale, Record<string, string>> = {
     includedFree: "inclus",
     orders: "commandes",
     // Delivery zone check
-    deliveryOutsideZone: "Desole, nous ne livrons pas encore a cette adresse.",
-    deliveryRefineAddress: "Veuillez saisir une adresse plus precise.",
+    deliveryOutsideZone: "Désolé, nous ne livrons pas encore à cette adresse.",
+    deliveryRefineAddress: "Veuillez saisir une adresse plus précise.",
   }
 };
 


### PR DESCRIPTION
Promotes current \`develop\` to production.

## Delivery zones — customer-facing enforcement
- On a delivery order, after the address settles, checkout calls the public delivery-check endpoint (debounced, with a stale-response guard), disables the place-order button, and shows a localized "we don't deliver here" / "refine your address" message when the address is outside every active zone.
- Pickup/dine-in are unaffected. On a network error it does not hard-block (the server-side order guard, already in prod, remains the backstop).
- Uses Google Places lat/lng when available, else the typed address/city (server geocodes). FR strings properly accented.

Pairs with the delivery-zone backend + admin already in production. Also carries other accumulated develop work (cover-logo size, checkout out-of-stock/min-order gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)