### PR TITLE
Promote develop → main: checkout city dropdown

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -20,6 +20,7 @@ import {
   checkTrustedCustomer,
   fetchMe,
   checkDeliveryAddress,
+  fetchDeliveryCities,
 } from "@/services/api";
 import { BatchFulfillmentConfigResponse, CheckoutConfig, OrderPayload, OrderType, Restaurant, SchedulingConfigResponse, SchedulingTimeSlot } from "@/lib/types";
 import { formatModifierLabel, lineTotal, lineUnitPrice } from "@/lib/cart";
@@ -130,6 +131,7 @@ function CheckoutContent() {
   const [deliveryNotes, setDeliveryNotes] = useState("");
   const [pickupNotes, setPickupNotes] = useState("");
   const [deliveryLatLng, setDeliveryLatLng] = useState<{ lat: number; lng: number } | null>(null);
+  const [deliveryCities, setDeliveryCities] = useState<string[]>([]);
 
   // Delivery zone check state
   type ZoneStatus = 'idle' | 'checking' | 'ok' | 'blocked';
@@ -391,6 +393,16 @@ function CheckoutContent() {
     }, 500);
     return () => { cancelled = true; clearTimeout(handle); };
   }, [orderType, deliveryLatLng, deliveryAddress, deliveryCity, restaurantId]);
+
+  // Fetch delivery cities when order type is delivery
+  useEffect(() => {
+    if (orderType !== 'delivery' || !restaurantId) return;
+    let active = true;
+    fetchDeliveryCities(restaurantId)
+      .then((c) => { if (active) setDeliveryCities(c); })
+      .catch(() => {});
+    return () => { active = false; };
+  }, [orderType, restaurantId]);
 
   // Send OTP mutation
   const sendOtpMutation = useMutation({
@@ -795,6 +807,7 @@ function CheckoutContent() {
                     <CheckoutBuilderFields
                       form={checkoutForm}
                       googlePlacesApiKey={effectivePlacesKey || undefined}
+                      cityOptions={deliveryCities}
                       state={{
                         customerName,
                         customerPhone,
@@ -915,14 +928,28 @@ function CheckoutContent() {
                               <label className="block text-sm font-medium text-[var(--text-muted)] mb-1">
                                 {t("deliveryCity")} *
                               </label>
-                              <input
-                                type="text"
-                                value={deliveryCity}
-                                onChange={(e) => setDeliveryCity(e.target.value)}
-                                required
-                                className="w-full px-4 py-3 border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
-                                placeholder={t("cityPlaceholder")}
-                              />
+                              {deliveryCities.length > 0 ? (
+                                <select
+                                  value={deliveryCity}
+                                  onChange={(e) => setDeliveryCity(e.target.value)}
+                                  required
+                                  className="w-full px-4 py-3 border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
+                                >
+                                  <option value="" disabled>{t("chooseCity") || "Choisir une ville"}</option>
+                                  {deliveryCities.map((city) => (
+                                    <option key={city} value={city}>{city}</option>
+                                  ))}
+                                </select>
+                              ) : (
+                                <input
+                                  type="text"
+                                  value={deliveryCity}
+                                  onChange={(e) => setDeliveryCity(e.target.value)}
+                                  required
+                                  className="w-full px-4 py-3 border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
+                                  placeholder={t("cityPlaceholder")}
+                                />
+                              )}
                             </div>
                             <div>
                               <label className="block text-sm font-medium text-[var(--text-muted)] mb-1">

--- a/components/CheckoutBuilderFields.tsx
+++ b/components/CheckoutBuilderFields.tsx
@@ -44,6 +44,9 @@ export interface CheckoutBuilderFieldsProps {
   onAddressGeocoded?: (lat: number, lng: number, city: string) => void;
   googlePlacesApiKey?: string;
   countrySelect?: React.ReactNode;
+  /** List of delivery cities from the restaurant config. When non-empty, the
+   *  delivery_city builtin field renders as a dropdown instead of a text input. */
+  cityOptions?: string[];
 }
 
 /**
@@ -60,7 +63,7 @@ export interface CheckoutBuilderFieldsProps {
  */
 export default function CheckoutBuilderFields({
   form, state, onBuiltinChange, onCustomChange, onAddressGeocoded,
-  googlePlacesApiKey, countrySelect,
+  googlePlacesApiKey, countrySelect, cityOptions,
 }: CheckoutBuilderFieldsProps) {
   const { locale, t } = useI18n();
   const addressInputRef = useRef<HTMLInputElement | null>(null);
@@ -135,6 +138,7 @@ export default function CheckoutBuilderFields({
             }}
             addressInputRef={field.id === 'delivery_address' ? addressInputRef : undefined}
             countrySelect={field.id === 'customer_phone' ? countrySelect : undefined}
+            cityOptions={field.id === 'delivery_city' ? cityOptions : undefined}
           />
         );
       })}
@@ -144,7 +148,7 @@ export default function CheckoutBuilderFields({
 }
 
 function FieldRow({
-  field, locale, value, onChange, addressInputRef, countrySelect,
+  field, locale, value, onChange, addressInputRef, countrySelect, cityOptions,
 }: {
   field: CheckoutFieldConfig;
   locale: string;
@@ -152,7 +156,9 @@ function FieldRow({
   onChange: (v: string | boolean) => void;
   addressInputRef?: React.MutableRefObject<HTMLInputElement | null>;
   countrySelect?: React.ReactNode;
+  cityOptions?: string[];
 }) {
+  const { t } = useI18n();
   const label = (
     localisedText(field.label, locale)
     || localisedText(BUILTIN_DEFAULT_LABELS[field.id], locale)
@@ -160,6 +166,26 @@ function FieldRow({
   );
   const placeholder = localisedText(field.placeholder, locale);
   const type = field.type ?? (field.kind === 'builtin' ? builtinDefaultType(field.id) : 'text');
+
+  // When city options are provided for delivery_city, render a dropdown
+  if (field.id === 'delivery_city' && cityOptions && cityOptions.length > 0) {
+    return (
+      <div>
+        <Label text={label} required={field.required} />
+        <select
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          required={field.required}
+          className="w-full px-4 py-3 border border-[var(--divider)] rounded-xl focus:outline-none focus:ring-2 focus:ring-brand bg-[var(--surface)] text-[var(--text)]"
+        >
+          <option value="" disabled>{t('chooseCity') || 'Choisir une ville'}</option>
+          {cityOptions.map((city) => (
+            <option key={city} value={city}>{city}</option>
+          ))}
+        </select>
+      </div>
+    );
+  }
 
   if (type === 'checkbox') {
     return (

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -458,6 +458,7 @@ const translations: Record<Locale, Record<string, string>> = {
     // Delivery zone check
     deliveryOutsideZone: "Sorry, we don't deliver to this address yet.",
     deliveryRefineAddress: "Please enter a more specific address.",
+    chooseCity: "Choose a city",
   },
   he: {
     all: "הכל",
@@ -912,6 +913,7 @@ const translations: Record<Locale, Record<string, string>> = {
     // Delivery zone check
     deliveryOutsideZone: "מצטערים, איננו מבצעים משלוחים לכתובת זו עדיין.",
     deliveryRefineAddress: "אנא הזינו כתובת מדויקת יותר.",
+    chooseCity: "בחרו עיר",
   },
   fr: {
     all: "Tout",
@@ -1366,6 +1368,7 @@ const translations: Record<Locale, Record<string, string>> = {
     // Delivery zone check
     deliveryOutsideZone: "Désolé, nous ne livrons pas encore à cette adresse.",
     deliveryRefineAddress: "Veuillez saisir une adresse plus précise.",
+    chooseCity: "Choisir une ville",
   }
 };
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -1014,6 +1014,14 @@ export async function fetchBatchFulfillmentConfig(
   };
 }
 
+/** Fetch the list of delivery cities configured for a restaurant. */
+export async function fetchDeliveryCities(restaurantId: string): Promise<string[]> {
+  const res = await fetch(`${PUBLIC_PREFIX}/delivery/cities?restaurant_id=${encodeURIComponent(restaurantId)}`);
+  if (!res.ok) return [];
+  const data = await handleResponse<{ cities: string[] }>(res);
+  return data.cities ?? [];
+}
+
 /** Check if a phone number is a trusted customer for a restaurant. */
 export async function checkTrustedCustomer(
   restaurantId: string,


### PR DESCRIPTION
For delivery, the checkout city field becomes a dropdown of the restaurant's saved delivery cities (both checkout layouts); falls back to a text field when no cities are saved (radius mode). Free, no Google.

Depends on the foodyserver deliverable-cities endpoint PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)