### PR TITLE
feat(checkout): split-name first-name composes into customer_name

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -120,6 +120,10 @@ function CheckoutContent() {
 
   // Form state
   const [step, setStep] = useState<CheckoutStep>("details");
+  // Optional split-name first-name field (built-in "customer_first_name"). When
+  // the owner's checkout form uses it, it's prepended to customerName at submit
+  // so the order still carries a single composed customer_name.
+  const [customerFirstName, setCustomerFirstName] = useState("");
   const [customerName, setCustomerName] = useState("");
   const [customerPhone, setCustomerPhone] = useState("");
   const [customerEmail, setCustomerEmail] = useState("");
@@ -484,6 +488,14 @@ function CheckoutContent() {
         }
       }
 
+      // When the owner's checkout form splits the name into Prénom + Nom, the
+      // first-name field is prepended so the order carries one composed
+      // customer_name ("Prénom Nom"). Falls back to customerName untouched for
+      // single-field and legacy flows.
+      const composedCustomerName =
+        [customerFirstName, customerName].map((s) => s.trim()).filter(Boolean).join(" ") ||
+        customerName;
+
       const { guestId, guestName } = useTableSession.getState();
       // Dine-in = pay later; batch fulfillment without prepayment = pay later;
       // everything else (pickup, delivery, counter, scheduled) = pay before
@@ -502,7 +514,7 @@ function CheckoutContent() {
         guestId: guestId || undefined,
         guestName: guestName || undefined,
         orderType,
-        customerName,
+        customerName: composedCustomerName,
         customerPhone: normalizePhone(customerPhone),
         customerEmail: customerEmail.trim() || undefined,
         deliveryAddress: orderType === "delivery" ? deliveryAddress : undefined,
@@ -809,6 +821,7 @@ function CheckoutContent() {
                       googlePlacesApiKey={effectivePlacesKey || undefined}
                       cityOptions={deliveryCities}
                       state={{
+                        customerFirstName,
                         customerName,
                         customerPhone,
                         deliveryAddress,
@@ -821,6 +834,7 @@ function CheckoutContent() {
                       }}
                       onBuiltinChange={(id, v) => {
                         switch (id) {
+                          case "customer_first_name": setCustomerFirstName(v); break;
                           case "customer_name":    setCustomerName(v); break;
                           case "customer_phone":   setCustomerPhone(v); break;
                           case "delivery_address": setDeliveryAddress(v); break;

--- a/components/CheckoutBuilderFields.tsx
+++ b/components/CheckoutBuilderFields.tsx
@@ -13,6 +13,7 @@ import type { CheckoutFieldConfig, CheckoutFormConfig } from '@/lib/types';
 // Default label fallbacks for built-in fields (when the owner left labels blank).
 // Indexed by field id + UI locale (en/he/fr).
 const BUILTIN_DEFAULT_LABELS: Record<string, Record<string, string>> = {
+  customer_first_name: { en: 'First name',      he: 'שם פרטי',      fr: 'Prénom' },
   customer_name:    { en: 'Full name',         he: 'שם מלא',       fr: 'Nom complet' },
   customer_phone:   { en: 'Phone number',      he: 'טלפון',        fr: 'Téléphone' },
   delivery_address: { en: 'Delivery address',  he: 'כתובת למשלוח', fr: 'Adresse de livraison' },
@@ -25,6 +26,7 @@ const BUILTIN_DEFAULT_LABELS: Record<string, Record<string, string>> = {
 };
 
 interface BuilderState {
+  customerFirstName: string;
   customerName: string;
   customerPhone: string;
   deliveryAddress: string;
@@ -72,6 +74,7 @@ export default function CheckoutBuilderFields({
   // Booleans for checkbox-typed custom fields; strings everywhere else.
   const valuesById = useMemo(() => {
     const m: Record<string, string | boolean> = {
+      customer_first_name: state.customerFirstName,
       customer_name:    state.customerName,
       customer_phone:   state.customerPhone,
       delivery_address: state.deliveryAddress,

--- a/lib/checkout-fields.ts
+++ b/lib/checkout-fields.ts
@@ -29,6 +29,7 @@ export function resolveCheckoutForm(
 // Anything not listed here is treated as a custom field and stored in
 // customFields by the caller.
 export const BUILTIN_FIELD_IDS = new Set<string>([
+  'customer_first_name',
   'customer_name',
   'customer_phone',
   'delivery_address',


### PR DESCRIPTION
Promotes split-name checkout to production (foodyweb side).

## What
Adds the `customer_first_name` built-in checkout field. When the owner's form uses it (Prénom + Nom), the first name is prepended to `customer_name` on submit so the order carries one composed name. Legacy and single-field flows are unchanged.

## Dependency
Requires the foodyserver PR (whitelists the field id) to ship first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)