### PR TITLE
Combo component availability + checkout gate (prod promote)

### DIFF
--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -259,6 +259,12 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
     for (const step of combo.steps) {
       if (step.items.length === 1 && step.minPicks > 0) {
         const only = step.items[0];
+        // Never silently pre-fill a sold-out single-item step. (In practice the
+        // combo tile is already grayed when this happens via the server rollup;
+        // this guards the race where stock dropped after the menu was loaded.)
+        if (only.menuItem.availabilityState === 'sold_out') {
+          continue;
+        }
         initialSelections.push({
           stepId: step.id,
           stepName: step.name,

--- a/lib/__tests__/cart-availability.test.ts
+++ b/lib/__tests__/cart-availability.test.ts
@@ -71,14 +71,6 @@ test("low state with no buildableCount is ok", () => {
   assert.deepEqual(result, { status: "ok" });
 });
 
-test("combo lines are not proactively checked (server guard is the safety net)", () => {
-  const result = computeLineAvailability(
-    line({ comboId: 42, item: menuItem({ id: "combo-42" }) }),
-    availMap([["combo-42", { state: "sold_out" }]]),
-  );
-  assert.deepEqual(result, { status: "ok" });
-});
-
 test("item missing from the fresh menu passes through as ok", () => {
   const result = computeLineAvailability(line(), availMap([]));
   assert.deepEqual(result, { status: "ok" });

--- a/lib/__tests__/cart-availability.test.ts
+++ b/lib/__tests__/cart-availability.test.ts
@@ -83,3 +83,22 @@ test("item missing from the fresh menu passes through as ok", () => {
   const result = computeLineAvailability(line(), availMap([]));
   assert.deepEqual(result, { status: "ok" });
 });
+
+test("combo line sold out via rolled-up combo state", () => {
+  const line = { id: "l1", comboId: "77", item: { id: "77" }, quantity: 1 } as any;
+  const result = computeLineAvailability(line, availMap([["77", { state: "sold_out" }]]));
+  assert.deepEqual(result, { status: "sold_out" });
+});
+
+test("combo line ok when combo available, ignoring per-item count", () => {
+  const line = { id: "l2", comboId: "77", item: { id: "77" }, quantity: 3 } as any;
+  // buildableCount must NOT gate a combo line — components own that via the guard.
+  const result = computeLineAvailability(line, availMap([["77", { state: "available", buildableCount: 1 }]]));
+  assert.deepEqual(result, { status: "ok" });
+});
+
+test("combo line ok when combo absent from menu", () => {
+  const line = { id: "l3", comboId: "88", item: { id: "88" }, quantity: 1 } as any;
+  const result = computeLineAvailability(line, availMap([]));
+  assert.deepEqual(result, { status: "ok" });
+});

--- a/lib/cart-availability.ts
+++ b/lib/cart-availability.ts
@@ -20,8 +20,10 @@ export type LineAvailability =
  * Classifies a cart line against the restaurant's current item availability so the
  * checkout can flag (and offer to fix) lines that can no longer be fulfilled.
  *
- * Combo lines and items absent from the fresh menu pass through as `ok` — the
- * server-side availability guard remains the authoritative safety net for those.
+ * Combo lines resolve against the combo's rolled-up `sold_out` state; component
+ * counts remain the server guard's responsibility. Items absent from the fresh menu
+ * pass through as `ok` — the server-side availability guard is the authoritative
+ * safety net for those.
  *
  * @param line The cart line to check.
  * @param availability Map of item id → current availability, built from `fetchMenu`.
@@ -30,17 +32,19 @@ export function computeLineAvailability(
   line: CartLine,
   availability: Map<string, ItemAvailability>,
 ): LineAvailability {
-  // Combos resolve their stock across multiple step items; the server guard owns
-  // that case. Don't half-check it here.
-  if (line.comboId != null) return { status: "ok" };
-
-  const info = availability.get(line.item.id);
-  // Item vanished from the menu between adding and checkout — let the server decide.
+  // Combo lines look up the combo's own rolled-up state (the server marks a combo
+  // sold_out when a required step is fully out). Component-level counts stay the
+  // server guard's job — only the sold_out roll-up gates here.
+  const key = line.comboId != null ? String(line.comboId) : line.item.id;
+  const info = availability.get(key);
+  // Item/combo vanished from the menu between adding and checkout — let the server decide.
   if (!info) return { status: "ok" };
 
   if (info.available === false || info.state === "sold_out" || info.state === "hidden") {
     return { status: "sold_out" };
   }
+
+  if (line.comboId != null) return { status: "ok" };
 
   const count = info.buildableCount;
   if (count != null && count < line.quantity) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -200,6 +200,8 @@ export type ComboStepItem = {
     description?: string;
     price: number;
     imageUrl?: string;
+    availabilityState?: 'available' | 'low' | 'sold_out' | 'hidden';
+    buildableCount?: number | null;
   };
 };
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -347,6 +347,8 @@ function _mapCategories(rawCats: Array<{ id: number; name?: string; Name?: strin
             description: si.menu_item.description || '',
             price: Number(si.menu_item.price ?? 0),
             imageUrl: si.menu_item.image_url || '',
+            availabilityState: si.menu_item.availability_state || undefined,
+            buildableCount: si.menu_item.buildable_count ?? null,
           } : undefined,
         })),
       })),


### PR DESCRIPTION
Promote combo-component availability fix to production (web).

- Parse combo component availability; skip auto-selecting a sold-out single-item combo step.
- Checkout gates combo lines on the combo's rolled-up sold_out state (lights the existing translated out-of-stock banner instead of the raw English rejection).

Part of a 3-repo promotion (server -> web -> pos). Merge AFTER server #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)