### PR TITLE
fix(checkout): prevent minimum-order banner flash after placing order

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -182,9 +182,11 @@ function CheckoutContent() {
     [lines]
   );
 
-  // Minimum order check for delivery
+  // Minimum order check for delivery. Suppressed once the order is placed: on
+  // success we clear() the cart, which zeroes displayTotal and would otherwise
+  // flash the "below minimum" banner for a frame before the redirect completes.
   const minimumOrderDelivery = restaurant?.minimumOrderDelivery ?? 0;
-  const isBelowMinimum = orderType === "delivery" && minimumOrderDelivery > 0 && displayTotal < minimumOrderDelivery;
+  const isBelowMinimum = !orderPlaced && orderType === "delivery" && minimumOrderDelivery > 0 && displayTotal < minimumOrderDelivery;
 
   // Fresh availability — re-checked at checkout so an item that sold out since being
   // added to the cart is caught before the customer pays, not only by the server guard.


### PR DESCRIPTION
## What
Fixes a one-frame flash of the "minimum order not met" banner on the checkout confirm step after the customer clicks "passer commande".

## Root cause
On a successful order, `onSuccess` calls `clear()` to empty the cart before the redirect fires. That drops `displayTotal` to `0` (below `minimumOrderDelivery`), flipping `isBelowMinimum` from `false` → `true` for the frame between the clear and the navigation completing — flashing the amber banner.

## Fix
Gate `isBelowMinimum` on `!orderPlaced`, the same signal that already guards the empty-cart redirect. Since `orderPlaced` is set `true` (and never reset) right before `clear()`, the banner can't reappear after submit, regardless of React update batching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)