### PR TITLE
feat: show delivery fee at city selection + full address in order recap

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -987,6 +987,32 @@ function CheckoutContent() {
                             )}
                           </div>
 
+                          {/* Delivery fee + zone feedback, shown as soon as a city
+                              is chosen so the customer sees the fee up front — not
+                              only in the final total recap. */}
+                          {deliveryCity.trim() && zoneStatus === "ok" && (
+                            <div className="space-y-1">
+                              <div className="flex items-center justify-between rounded-xl bg-[var(--surface-subtle)] px-4 py-2.5 text-sm">
+                                <span className="text-[var(--text-muted)]">{t("deliveryFee")}</span>
+                                <span className="font-semibold">
+                                  {appliedDeliveryFee > 0 ? `${currency} ${appliedDeliveryFee.toFixed(2)}` : t("free")}
+                                </span>
+                              </div>
+                              {minimumOrderDelivery > 0 && (
+                                <p className="text-xs text-[var(--text-muted)]">
+                                  {t("minimumOrderInfo") || "Minimum order for delivery:"} {currency} {minimumOrderDelivery.toFixed(2)}
+                                </p>
+                              )}
+                            </div>
+                          )}
+                          {deliveryCity.trim() && zoneStatus === "blocked" && (
+                            <p className="text-sm text-red-500">
+                              {zoneReason === "address_unresolved"
+                                ? (t("deliveryRefineAddress") || "Please enter a more specific address.")
+                                : (t("deliveryOutsideZone") || "Sorry, we don't deliver to this address yet.")}
+                            </p>
+                          )}
+
                           {deliveryCity.trim() && (
                             <>
                               <div>
@@ -1351,8 +1377,15 @@ function CheckoutContent() {
                   <div className="text-sm text-[var(--text-muted)]">
                     <p>{customerName}</p>
                     {customerPhone && <p dir="ltr" className="font-mono">{customerPhone}</p>}
-                    {orderType === "delivery" && deliveryAddress && (
-                      <p className="mt-1">{deliveryAddress}</p>
+                    {orderType === "delivery" && (deliveryAddress || deliveryCity || deliveryFloor || deliveryApt || deliveryNotes) && (
+                      <div className="mt-1 space-y-0.5">
+                        {deliveryAddress && <p>{deliveryAddress}</p>}
+                        {deliveryCity && <p>{deliveryCity}</p>}
+                        {(deliveryFloor || deliveryApt) && (
+                          <p>{t("deliveryFloor")}: {[deliveryFloor, deliveryApt].filter(Boolean).join(" · ")}</p>
+                        )}
+                        {deliveryNotes && <p className="italic">{deliveryNotes}</p>}
+                      </div>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

Two checkout refinements following #89 (per-zone delivery fee at checkout):

1. **Delivery fee shown at city selection.** As soon as the customer picks their delivery city, the per-zone fee (or "Free") and the effective minimum order are shown right under the city field — instead of only appearing in the final total recap. An early "we don't deliver here / refine your address" message is shown when the zone check blocks.
2. **Fuller delivery info in the order recap.** The confirm-step delivery card previously showed only the street address. It now also shows the **city**, **floor / apartment**, and **delivery notes** when present.

## Changes

- `app/order/checkout/page.tsx`
  - Fee + minimum + zone-status block rendered under the city field once a city is chosen (reuses the existing `zoneStatus` / `appliedDeliveryFee` / `minimumOrderDelivery` state).
  - Recap delivery block expanded to render address, city, floor/apt, and notes.

No new translation keys — reuses existing `deliveryFee`, `free`, `minimumOrderInfo`, `deliveryFloor`, `deliveryRefineAddress`, `deliveryOutsideZone`.

## Testing

- `npx tsc --noEmit` clean.
- `npm run lint` passes (only pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zgTHxxQFVYHD1HczB8iva)_