### PR TITLE
fix: show delivery fee at city step for checkout-builder forms

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -987,32 +987,6 @@ function CheckoutContent() {
                             )}
                           </div>
 
-                          {/* Delivery fee + zone feedback, shown as soon as a city
-                              is chosen so the customer sees the fee up front — not
-                              only in the final total recap. */}
-                          {deliveryCity.trim() && zoneStatus === "ok" && (
-                            <div className="space-y-1">
-                              <div className="flex items-center justify-between rounded-xl bg-[var(--surface-subtle)] px-4 py-2.5 text-sm">
-                                <span className="text-[var(--text-muted)]">{t("deliveryFee")}</span>
-                                <span className="font-semibold">
-                                  {appliedDeliveryFee > 0 ? `${currency} ${appliedDeliveryFee.toFixed(2)}` : t("free")}
-                                </span>
-                              </div>
-                              {minimumOrderDelivery > 0 && (
-                                <p className="text-xs text-[var(--text-muted)]">
-                                  {t("minimumOrderInfo") || "Minimum order for delivery:"} {currency} {minimumOrderDelivery.toFixed(2)}
-                                </p>
-                              )}
-                            </div>
-                          )}
-                          {deliveryCity.trim() && zoneStatus === "blocked" && (
-                            <p className="text-sm text-red-500">
-                              {zoneReason === "address_unresolved"
-                                ? (t("deliveryRefineAddress") || "Please enter a more specific address.")
-                                : (t("deliveryOutsideZone") || "Sorry, we don't deliver to this address yet.")}
-                            </p>
-                          )}
-
                           {deliveryCity.trim() && (
                             <>
                               <div>
@@ -1057,6 +1031,32 @@ function CheckoutContent() {
                         </>
                       )}
                     </>
+                  )}
+
+                  {/* Delivery fee + zone feedback — rendered for both the builder
+                      and legacy forms once a delivery city is resolved, so the
+                      customer sees the fee up front (not only in the total recap). */}
+                  {orderType === "delivery" && deliveryCity.trim() && zoneStatus === "ok" && (
+                    <div className="space-y-1">
+                      <div className="flex items-center justify-between rounded-xl bg-[var(--surface-subtle)] px-4 py-2.5 text-sm">
+                        <span className="text-[var(--text-muted)]">{t("deliveryFee")}</span>
+                        <span className="font-semibold">
+                          {appliedDeliveryFee > 0 ? `${currency} ${appliedDeliveryFee.toFixed(2)}` : t("free")}
+                        </span>
+                      </div>
+                      {minimumOrderDelivery > 0 && (
+                        <p className="text-xs text-[var(--text-muted)]">
+                          {t("minimumOrderInfo") || "Minimum order for delivery:"} {currency} {minimumOrderDelivery.toFixed(2)}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                  {orderType === "delivery" && deliveryCity.trim() && zoneStatus === "blocked" && (
+                    <p className="text-sm text-red-500">
+                      {zoneReason === "address_unresolved"
+                        ? (t("deliveryRefineAddress") || "Please enter a more specific address.")
+                        : (t("deliveryOutsideZone") || "Sorry, we don't deliver to this address yet.")}
+                    </p>
                   )}
 
                   {/* Batch fulfillment summary — at checkout we want the full


### PR DESCRIPTION
## Summary

Follow-up to #90, which merged before this commit was pushed. In #90 the delivery-fee / zone-feedback block was nested inside the **legacy** hard-coded delivery form, so restaurants using the **checkout-form builder** (custom fields like "Code Immeuble", "Appartement", "Informations supplémentaires") never saw the fee at the details step — it only appeared in the total recap on the next step.

This moves the fee + minimum + zone-status block to a **shared** spot that renders after the form fields for **both** the builder and legacy paths, gated on a resolved delivery city (`orderType === "delivery" && deliveryCity && zoneStatus === "ok"`).

## Changes

- `app/order/checkout/page.tsx`: delivery-fee block lifted out of the legacy-only branch into the common form area (renders for builder + legacy).

## Testing

- `npx tsc --noEmit` clean.
- `npm run lint` passes (pre-existing warnings only).

## Note on the cities vs radius/polygon zones
For **cities-type** zones the fee shows immediately on city select. For **radius/polygon** zones the fee can only resolve once an address is entered (it needs to geocode), so until then the customer sees the refine-address hint rather than a fee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zgTHxxQFVYHD1HczB8iva)_