### PR TITLE
feat: place delivery fee right after the city field (before address)

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -203,8 +203,16 @@ function CheckoutContent() {
 
   // Delivery fee / zone feedback shown right after the city field (both the
   // builder and legacy forms) so the customer sees the fee before filling in
-  // the rest of the address — not buried at the bottom of the form.
-  const deliveryFeeNotice = orderType === "delivery" && deliveryCity.trim() ? (
+  // the rest of the address — not buried at the bottom of the form. Before a
+  // city is chosen, a generic heads-up explains the fee can vary by city (only
+  // when the restaurant uses a city list, i.e. fees can actually differ).
+  const deliveryFeeNotice = orderType !== "delivery" ? null : !deliveryCity.trim() ? (
+    deliveryCities.length > 0 ? (
+      <p className="text-xs text-[var(--text-muted)]">
+        {t("deliveryFeeVariesHint") || "Des frais de livraison peuvent s'appliquer selon la ville choisie."}
+      </p>
+    ) : null
+  ) : (
     <>
       {zoneStatus === "ok" && (
         <div className="space-y-1">
@@ -229,7 +237,7 @@ function CheckoutContent() {
         </p>
       )}
     </>
-  ) : null;
+  );
 
   // Fresh availability — re-checked at checkout so an item that sold out since being
   // added to the cart is caught before the customer pays, not only by the server guard.

--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -201,6 +201,36 @@ function CheckoutContent() {
   const appliedDeliveryFee = orderType === "delivery" && zoneStatus === "ok" ? deliveryFee : 0;
   const grandTotal = displayTotal + appliedDeliveryFee;
 
+  // Delivery fee / zone feedback shown right after the city field (both the
+  // builder and legacy forms) so the customer sees the fee before filling in
+  // the rest of the address — not buried at the bottom of the form.
+  const deliveryFeeNotice = orderType === "delivery" && deliveryCity.trim() ? (
+    <>
+      {zoneStatus === "ok" && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between rounded-xl bg-[var(--surface-subtle)] px-4 py-2.5 text-sm">
+            <span className="text-[var(--text-muted)]">{t("deliveryFee")}</span>
+            <span className="font-semibold">
+              {appliedDeliveryFee > 0 ? `${currency} ${appliedDeliveryFee.toFixed(2)}` : t("free")}
+            </span>
+          </div>
+          {minimumOrderDelivery > 0 && (
+            <p className="text-xs text-[var(--text-muted)]">
+              {t("minimumOrderInfo") || "Minimum order for delivery:"} {currency} {minimumOrderDelivery.toFixed(2)}
+            </p>
+          )}
+        </div>
+      )}
+      {zoneStatus === "blocked" && (
+        <p className="text-sm text-red-500">
+          {zoneReason === "address_unresolved"
+            ? (t("deliveryRefineAddress") || "Please enter a more specific address.")
+            : (t("deliveryOutsideZone") || "Sorry, we don't deliver to this address yet.")}
+        </p>
+      )}
+    </>
+  ) : null;
+
   // Fresh availability — re-checked at checkout so an item that sold out since being
   // added to the cart is caught before the customer pays, not only by the server guard.
   const { data: freshMenu, refetch: refetchAvailability } = useQuery({
@@ -879,6 +909,7 @@ function CheckoutContent() {
                       }}
                       onCustomChange={(id, v) => setCustomFieldValues((prev) => ({ ...prev, [id]: v }))}
                       onAddressGeocoded={(lat, lng) => setDeliveryLatLng({ lat, lng })}
+                      renderAfterField={(id) => (id === "delivery_city" ? deliveryFeeNotice : null)}
                       countrySelect={(
                         <select
                           value={countryCode}
@@ -987,6 +1018,9 @@ function CheckoutContent() {
                             )}
                           </div>
 
+                          {/* Fee shown right after the city, before the address fields. */}
+                          {deliveryFeeNotice}
+
                           {deliveryCity.trim() && (
                             <>
                               <div>
@@ -1031,32 +1065,6 @@ function CheckoutContent() {
                         </>
                       )}
                     </>
-                  )}
-
-                  {/* Delivery fee + zone feedback — rendered for both the builder
-                      and legacy forms once a delivery city is resolved, so the
-                      customer sees the fee up front (not only in the total recap). */}
-                  {orderType === "delivery" && deliveryCity.trim() && zoneStatus === "ok" && (
-                    <div className="space-y-1">
-                      <div className="flex items-center justify-between rounded-xl bg-[var(--surface-subtle)] px-4 py-2.5 text-sm">
-                        <span className="text-[var(--text-muted)]">{t("deliveryFee")}</span>
-                        <span className="font-semibold">
-                          {appliedDeliveryFee > 0 ? `${currency} ${appliedDeliveryFee.toFixed(2)}` : t("free")}
-                        </span>
-                      </div>
-                      {minimumOrderDelivery > 0 && (
-                        <p className="text-xs text-[var(--text-muted)]">
-                          {t("minimumOrderInfo") || "Minimum order for delivery:"} {currency} {minimumOrderDelivery.toFixed(2)}
-                        </p>
-                      )}
-                    </div>
-                  )}
-                  {orderType === "delivery" && deliveryCity.trim() && zoneStatus === "blocked" && (
-                    <p className="text-sm text-red-500">
-                      {zoneReason === "address_unresolved"
-                        ? (t("deliveryRefineAddress") || "Please enter a more specific address.")
-                        : (t("deliveryOutsideZone") || "Sorry, we don't deliver to this address yet.")}
-                    </p>
                   )}
 
                   {/* Batch fulfillment summary — at checkout we want the full

--- a/components/CheckoutBuilderFields.tsx
+++ b/components/CheckoutBuilderFields.tsx
@@ -58,6 +58,9 @@ export interface CheckoutBuilderFieldsProps {
   /** List of delivery cities from the restaurant config. When non-empty, the
    *  delivery_city builtin field renders as a dropdown instead of a text input. */
   cityOptions?: string[];
+  /** Optional extra content rendered immediately after a given field, by id.
+   *  Used to surface the delivery fee right under the city field. */
+  renderAfterField?: (fieldId: string) => React.ReactNode;
 }
 
 /**
@@ -74,7 +77,7 @@ export interface CheckoutBuilderFieldsProps {
  */
 export default function CheckoutBuilderFields({
   form, state, onBuiltinChange, onCustomChange, onAddressGeocoded,
-  googlePlacesApiKey, countrySelect, cityOptions,
+  googlePlacesApiKey, countrySelect, cityOptions, renderAfterField,
 }: CheckoutBuilderFieldsProps) {
   const { locale, t } = useI18n();
   const addressInputRef = useRef<HTMLInputElement | null>(null);
@@ -149,20 +152,23 @@ export default function CheckoutBuilderFields({
         if (!field.enabled) return null;
         if (cityGateActive && CITY_GATED_FIELD_IDS.has(field.id)) return null;
         if (!evaluateVisibility(field.visible_when ?? null, valuesById)) return null;
+        const after = renderAfterField?.(field.id);
         return (
-          <FieldRow
-            key={field.id}
-            field={field}
-            locale={locale}
-            value={(valuesById[field.id] as string | boolean) ?? (field.type === 'checkbox' ? false : '')}
-            onChange={(v) => {
-              if (BUILTIN_FIELD_IDS.has(field.id)) onBuiltinChange(field.id, String(v));
-              else onCustomChange(field.id, v);
-            }}
-            addressInputRef={field.id === 'delivery_address' ? addressInputRef : undefined}
-            countrySelect={field.id === 'customer_phone' ? countrySelect : undefined}
-            cityOptions={field.id === 'delivery_city' ? cityOptions : undefined}
-          />
+          <div key={field.id} className="space-y-4">
+            <FieldRow
+              field={field}
+              locale={locale}
+              value={(valuesById[field.id] as string | boolean) ?? (field.type === 'checkbox' ? false : '')}
+              onChange={(v) => {
+                if (BUILTIN_FIELD_IDS.has(field.id)) onBuiltinChange(field.id, String(v));
+                else onCustomChange(field.id, v);
+              }}
+              addressInputRef={field.id === 'delivery_address' ? addressInputRef : undefined}
+              countrySelect={field.id === 'customer_phone' ? countrySelect : undefined}
+              cityOptions={field.id === 'delivery_city' ? cityOptions : undefined}
+            />
+            {after}
+          </div>
         );
       })}
       {t === t ? null : null /* keep t in deps for future */}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -81,6 +81,7 @@ const translations: Record<Locale, Record<string, string>> = {
     minimumOrderInfo: "Minimum order for delivery:",
     addMoreToReachMinimum: "Add more items to reach the minimum",
     deliveryFee: "Delivery fee",
+    deliveryFeeVariesHint: "Delivery fees may vary depending on the city you select.",
     cancel: "Cancel",
     continue: "Continue",
     // Checkout & OTP
@@ -542,6 +543,7 @@ const translations: Record<Locale, Record<string, string>> = {
     minimumOrderInfo: "מינימום הזמנה למשלוח:",
     addMoreToReachMinimum: "הוסף עוד פריטים כדי להגיע למינימום",
     deliveryFee: "דמי משלוח",
+    deliveryFeeVariesHint: "ייתכנו דמי משלוח משתנים בהתאם לעיר שתבחרו.",
     cancel: "ביטול",
     continue: "המשך",
     // Checkout & OTP
@@ -1003,6 +1005,7 @@ const translations: Record<Locale, Record<string, string>> = {
     minimumOrderInfo: "Commande minimum pour la livraison :",
     addMoreToReachMinimum: "Ajoutez des articles pour atteindre le minimum",
     deliveryFee: "Frais de livraison",
+    deliveryFeeVariesHint: "Des frais de livraison peuvent s'appliquer selon la ville choisie.",
     cancel: "Annuler",
     continue: "Continuer",
     // Checkout & OTP


### PR DESCRIPTION
## Summary

Follow-up to #91. The fee now appeared in the builder form, but at the **bottom** of the details form — after the customer had already filled in address, building code, floor, apartment, and notes. The point of showing the fee is so they can decide **before** doing all that work.

This moves the fee / zone-feedback notice to render **immediately after the city field** in both forms.

## Changes

- `app/order/checkout/page.tsx`
  - Extracted the fee/zone notice into a single `deliveryFeeNotice` node.
  - Legacy form: rendered right after the city field (before the gated address fields).
  - Removed the bottom-of-form copy.
- `components/CheckoutBuilderFields.tsx`
  - New optional `renderAfterField(fieldId)` slot; the page passes `deliveryFeeNotice` for `delivery_city`, so the builder places it directly under the city dropdown.

Since the builder's address fields are already gated behind city selection, the customer now sees: **City → Delivery fee → (then) address / code / floor / apt / notes**.

## Testing

- `npx tsc --noEmit` clean.
- `npm run lint` passes (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zgTHxxQFVYHD1HczB8iva)_