### PR TITLE
fix: drop redundant minimum-order line under the city delivery fee

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -215,18 +215,11 @@ function CheckoutContent() {
   ) : (
     <>
       {zoneStatus === "ok" && (
-        <div className="space-y-1">
-          <div className="flex items-center justify-between rounded-xl bg-[var(--surface-subtle)] px-4 py-2.5 text-sm">
-            <span className="text-[var(--text-muted)]">{t("deliveryFee")}</span>
-            <span className="font-semibold">
-              {appliedDeliveryFee > 0 ? `${currency} ${appliedDeliveryFee.toFixed(2)}` : t("free")}
-            </span>
-          </div>
-          {minimumOrderDelivery > 0 && (
-            <p className="text-xs text-[var(--text-muted)]">
-              {t("minimumOrderInfo") || "Minimum order for delivery:"} {currency} {minimumOrderDelivery.toFixed(2)}
-            </p>
-          )}
+        <div className="flex items-center justify-between rounded-xl bg-[var(--surface-subtle)] px-4 py-2.5 text-sm">
+          <span className="text-[var(--text-muted)]">{t("deliveryFee")}</span>
+          <span className="font-semibold">
+            {appliedDeliveryFee > 0 ? `${currency} ${appliedDeliveryFee.toFixed(2)}` : t("free")}
+          </span>
         </div>
       )}
       {zoneStatus === "blocked" && (


### PR DESCRIPTION
## Summary

Follow-up to #92, which merged before this commit was pushed.

The city-step delivery-fee block showed both the fee **and** a "Minimum order for delivery: ILS X" line. The minimum is already enforced at the confirm step (the order is blocked and messaged when the subtotal is below it), so repeating it under the city fee was redundant noise. This keeps only the fee amount there.

## Changes

- `app/order/checkout/page.tsx`: removed the `minimumOrderInfo` line from the city-step delivery-fee notice. The fee row (and the out-of-zone message / pre-selection hint) are unchanged.

## Testing

- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zgTHxxQFVYHD1HczB8iva)_