### PR TITLE
fix: include delivery fee in checkout VAT breakdown

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -1476,15 +1476,15 @@ function CheckoutContent() {
                   })}
                 </div>
 
-                {/* Total with VAT Breakdown */}
+                {/* Total breakdown. Prices are VAT-inclusive, so we show gross
+                    lines that reconcile (subtotal + delivery = total) and surface
+                    the VAT contained in the total as an informational line. The
+                    delivery fee is treated as VAT-inclusive, so the VAT shown is
+                    computed on the whole total (items + delivery), not items alone. */}
                 <div className="space-y-2 border-t border-[var(--divider)] pt-4">
                   <div className="flex justify-between text-[var(--text-muted)]">
                     <span>{t("subtotal")}</span>
-                    <span>{currency} {(displayTotal / VAT_MULTIPLIER).toFixed(2)}</span>
-                  </div>
-                  <div className="flex justify-between text-[var(--text-muted)]">
-                    <span>{t("vat")} (18%)</span>
-                    <span>{currency} {(displayTotal - displayTotal / VAT_MULTIPLIER).toFixed(2)}</span>
+                    <span>{currency} {displayTotal.toFixed(2)}</span>
                   </div>
                   {orderType === "delivery" && zoneStatus === "ok" && (
                     <div className="flex justify-between text-[var(--text-muted)]">
@@ -1502,6 +1502,10 @@ function CheckoutContent() {
                     <p className="text-2xl">
                       {currency} {grandTotal.toFixed(2)}
                     </p>
+                  </div>
+                  <div className="flex justify-between text-xs text-[var(--text-muted)]">
+                    <span>{t("vatIncluded")} (18%)</span>
+                    <span>{currency} {(grandTotal - grandTotal / VAT_MULTIPLIER).toFixed(2)}</span>
                   </div>
                 </div>
 

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -136,6 +136,7 @@ const translations: Record<Locale, Record<string, string>> = {
     invalidOrderId: "Invalid order ID or restaurant ID",
     subtotal: "Subtotal",
     vat: "VAT",
+    vatIncluded: "incl. VAT",
     // Receipt & Order History
     order: "Order",
     date: "Date",
@@ -598,6 +599,7 @@ const translations: Record<Locale, Record<string, string>> = {
     invalidOrderId: "מספר הזמנה או מסעדה לא חוקי",
     subtotal: "סכום ביניים",
     vat: "מע״מ",
+    vatIncluded: "כולל מע״מ",
     // Receipt & Order History
     order: "הזמנה",
     date: "תאריך",
@@ -1060,6 +1062,7 @@ const translations: Record<Locale, Record<string, string>> = {
     invalidOrderId: "ID de commande ou de restaurant invalide",
     subtotal: "Sous-total",
     vat: "TVA",
+    vatIncluded: "dont TVA",
     // Receipt & Order History
     order: "Commande",
     date: "Date",


### PR DESCRIPTION
## Problem

The checkout VAT line was computed on the **items only**, ignoring the delivery fee. Example (your screenshot): items ₪480 + delivery ₪70 = ₪550, but the breakdown showed:

- Sous-total 406.78, TVA (18%) **73.22**, Frais de livraison 70, Total 550

The TVA shown (73.22) is the VAT of the items alone. The VAT actually contained in the ₪550 total is **83.90** — the ₪10.68 difference is the VAT inside the ₪70 fee. In Israel delivery is normally VAT-taxable, so the fee should be part of the VAT calculation.

## Fix

Switched to a VAT-inclusive presentation that reconciles and treats the fee as taxable:

- **Sous-total** ₪480.00 (items, gross)
- **Frais de livraison** ₪70.00 (gross)
- **Total** ₪550.00  ( = 480 + 70 )
- *incl. VAT (18%)* ₪83.90  — informational, the VAT contained in the total (items + fee)

The **charged amount is unchanged** — the server already totals items + fee (₪550). This only corrects the displayed tax decomposition. Applies to all order types (for pickup/dine-in with no fee, it's just subtotal = total with incl-VAT on the items).

Added `vatIncluded` string in en (`incl. VAT`) / he (`כולל מע״מ`) / fr (`dont TVA`).

## Testing
- `npx tsc --noEmit` clean.
- `npm run lint` passes (pre-existing warnings only).

## Note
This assumes delivery is VAT-taxable (standard in Israel). If your accountant says delivery should be VAT-exempt, this is easy to revert — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zgTHxxQFVYHD1HczB8iva)_