### PR TITLE
Promote develop → main: bare-logo cover mode + text case override + size-option reorder fix

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -184,7 +184,7 @@ export function MenuItemCard({
                 "font-bold text-[var(--text)] leading-tight",
                 "line-clamp-2"
               )}
-              style={roleTextStyle("itemName", "1em", "inherit", 700)}
+              style={roleTextStyle("itemName", "1em", "inherit", 700, "none")}
             >
               {itemName}
             </h3>
@@ -205,7 +205,7 @@ export function MenuItemCard({
                 "text-[var(--text-muted)] leading-relaxed",
                 "mt-1.5 line-clamp-2"
               )}
-              style={roleTextStyle("itemDescription", "0.875rem", "inherit", 400)}
+              style={roleTextStyle("itemDescription", "0.875rem", "inherit", 400, "none")}
             >
               {itemDescription}
             </p>

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -539,19 +539,33 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
           continue;
         }
         // Resolve the previously chosen variant for correct price/label.
+        let variantId = it.selected_variant_id;
         let variantName: string | undefined;
         let variantPrice: number | undefined;
-        if (it.selected_variant_id) {
+        if (variantId) {
           for (const os of item.optionSets ?? []) {
-            const opt = os.options.find((o) => o.id === it.selected_variant_id);
+            const opt = os.options.find((o) => o.id === variantId);
             if (opt) {
               variantName = opt.name;
               variantPrice = opt.onlinePrice ?? opt.price;
               break;
             }
           }
+        } else {
+          // Legacy line with no stored size on an item that has size options:
+          // default to the first option — the same one the item modal
+          // auto-selects — so the reordered line carries a real size instead
+          // of re-propagating the size-less shape.
+          const first = (item.optionSets ?? [])
+            .map((os) => (os.options ?? []).filter((o) => o.isActive)[0])
+            .find(Boolean);
+          if (first) {
+            variantId = first.id;
+            variantName = first.name;
+            variantPrice = first.onlinePrice ?? first.price;
+          }
         }
-        addItem(item, it.quantity || 1, undefined, undefined, it.selected_variant_id, variantName, variantPrice);
+        addItem(item, it.quantity || 1, undefined, undefined, variantId, variantName, variantPrice);
         added++;
       }
       if (added > 0) setCartOpen(true);

--- a/components/RestaurantHero.tsx
+++ b/components/RestaurantHero.tsx
@@ -143,8 +143,12 @@ export function RestaurantHero({
   // can't shrink to nothing or overflow the cover. 100% (1) = default look.
   const logoScale = Math.min(1.9, Math.max(0.4, (websiteConfig?.heroLogoSize ?? 100) / 100));
   // Cover composition. "logo" drops the name, tagline and rounded box and shows
-  // the logo on its own, centered on the cover.
+  // the logo on its own, centered on the cover. "bare" keeps the logo at the
+  // card position (straddling the cover's bottom edge on mobile, bottom-left
+  // on web) but drops the box, name and tagline.
   const isLogoCover = websiteConfig?.heroCoverLayout === "logo";
+  const isBareLogo = websiteConfig?.heroCoverLayout === "bare";
+  const hideBrandText = isLogoCover || isBareLogo;
   const heroFontWeights = heroNameFont
     ? websiteConfig?.typography?.extraFonts?.find((f) => f.family === heroNameFont)?.weights
     : undefined;
@@ -365,9 +369,9 @@ export function RestaurantHero({
           {/* Soft top gradient so the floating TopBar buttons stay legible */}
           <div className="absolute top-0 inset-x-0 h-24 bg-gradient-to-b from-black/35 to-transparent pointer-events-none" />
           {/* Web-only bottom gradient so the white brand text reads on the cover.
-              Skipped in logo-cover mode: there is no text, so it would only
-              darken the cover. */}
-          {!isLogoCover && (
+              Skipped in logo-cover and bare-logo modes: there is no text, so it
+              would only darken the cover. */}
+          {!hideBrandText && (
             <div className="hidden sm:block absolute inset-0 bg-gradient-to-t from-black/80 via-black/15 to-transparent pointer-events-none" />
           )}
         </div>
@@ -388,32 +392,45 @@ export function RestaurantHero({
 
         {/* WEB brand overlay — logo box + name + tagline pinned bottom-left,
             sitting entirely ON the cover (no straddle below it). items-center
-            keeps the logo vertically centered with the name + tagline. */}
+            keeps the logo vertically centered with the name + tagline. In
+            bare-logo mode the box chrome, name and tagline are dropped and the
+            logo renders on its own at the same spot. */}
         <div className={`${isLogoCover ? "hidden" : "hidden sm:flex"} absolute inset-x-0 bottom-0 items-center gap-5 px-6 lg:px-12 pb-8 pointer-events-none`}>
-          {hasLogo && (
-            <div
-              style={{ width: 110 * logoScale, height: 110 * logoScale }}
-              className={`shrink-0 rounded-[24px] flex items-center justify-center overflow-hidden border border-white/15 shadow-[0_10px_30px_rgba(0,0,0,0.5)] ${
-                logoBg === "black" ? "bg-black" : "bg-white"
-              }`}
-            >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={logoUrl} alt={restaurant.name} className="w-full h-full object-contain p-3" />
+          {hasLogo &&
+            (isBareLogo ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={logoUrl}
+                alt={restaurant.name}
+                style={{ width: 110 * logoScale, height: 110 * logoScale }}
+                className="shrink-0 object-contain drop-shadow-[0_6px_24px_rgba(0,0,0,0.45)]"
+              />
+            ) : (
+              <div
+                style={{ width: 110 * logoScale, height: 110 * logoScale }}
+                className={`shrink-0 rounded-[24px] flex items-center justify-center overflow-hidden border border-white/15 shadow-[0_10px_30px_rgba(0,0,0,0.5)] ${
+                  logoBg === "black" ? "bg-black" : "bg-white"
+                }`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={logoUrl} alt={restaurant.name} className="w-full h-full object-contain p-3" />
+              </div>
+            ))}
+          {!isBareLogo && (
+            <div className="min-w-0">
+              <h1
+                className="text-[42px] lg:text-[54px] leading-[1.0] font-extrabold tracking-[-0.02em] text-white drop-shadow-[0_2px_14px_rgba(0,0,0,0.6)] truncate"
+                style={nameFontStyle}
+              >
+                {restaurant.name}
+              </h1>
+              {tagline && (
+                <p className="mt-2 text-[13px] lg:text-[14px] font-bold uppercase tracking-[0.12em] text-white/80 drop-shadow-[0_1px_6px_rgba(0,0,0,0.6)]">
+                  {tagline}
+                </p>
+              )}
             </div>
           )}
-          <div className="min-w-0">
-            <h1
-              className="text-[42px] lg:text-[54px] leading-[1.0] font-extrabold tracking-[-0.02em] text-white drop-shadow-[0_2px_14px_rgba(0,0,0,0.6)] truncate"
-              style={nameFontStyle}
-            >
-              {restaurant.name}
-            </h1>
-            {tagline && (
-              <p className="mt-2 text-[13px] lg:text-[14px] font-bold uppercase tracking-[0.12em] text-white/80 drop-shadow-[0_1px_6px_rgba(0,0,0,0.6)]">
-                {tagline}
-              </p>
-            )}
-          </div>
         </div>
 
         {/* MOBILE logo — straddles the cover's bottom edge, centered. Anchored
@@ -426,12 +443,22 @@ export function RestaurantHero({
         {!isLogoCover && hasLogo && (
           <div
             style={{ width: 84 * logoScale, height: 84 * logoScale }}
-            className={`sm:hidden absolute left-1/2 bottom-0 z-20 -translate-x-1/2 translate-y-1/4 rounded-[20px] flex items-center justify-center overflow-hidden border border-[var(--divider)] shadow-[0_8px_24px_rgba(0,0,0,0.30)] ${
-              logoBg === "black" ? "bg-black" : "bg-white"
+            className={`sm:hidden absolute left-1/2 bottom-0 z-20 -translate-x-1/2 translate-y-1/4 flex items-center justify-center ${
+              isBareLogo
+                ? ""
+                : `rounded-[20px] overflow-hidden border border-[var(--divider)] shadow-[0_8px_24px_rgba(0,0,0,0.30)] ${
+                    logoBg === "black" ? "bg-black" : "bg-white"
+                  }`
             }`}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={logoUrl} alt={restaurant.name} className="w-full h-full object-contain p-2.5" />
+            <img
+              src={logoUrl}
+              alt={restaurant.name}
+              className={`w-full h-full object-contain ${
+                isBareLogo ? "drop-shadow-[0_6px_24px_rgba(0,0,0,0.45)]" : "p-2.5"
+              }`}
+            />
           </div>
         )}
       </div>
@@ -460,18 +487,19 @@ export function RestaurantHero({
           cover above. In logo-cover mode the name + tagline are dropped (the
           logo lives on the cover) and only the info line remains, so the band
           collapses to tight padding and is skipped entirely when there is no
-          info to show. */}
+          info to show. Bare-logo mode also drops the name + tagline but keeps
+          the tall top padding: the bare logo still straddles in from above. */}
       {(!isLogoCover || rowItems.length > 0) && (
         <div
           className={`sm:hidden relative px-5 text-center ${isLogoCover ? "pt-4 pb-4" : "pt-10 pb-6"}`}
           style={{ backgroundColor: "var(--hero-bg, var(--bg-page))" }}
         >
-          {!isLogoCover && tagline && (
+          {!hideBrandText && tagline && (
             <p className="text-[10.5px] font-bold uppercase tracking-[0.16em] text-[var(--text-soft)] mb-1.5">
               {tagline}
             </p>
           )}
-          {!isLogoCover && (
+          {!hideBrandText && (
             <h1
               className="text-[31px] leading-[1.04] font-extrabold tracking-[-0.02em]"
               style={{ ...nameFontStyle, color: "var(--hero-text, var(--text))" }}

--- a/components/themed/CategoryBanner/CategoryBanner.ColorTitle.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ColorTitle.tsx
@@ -97,10 +97,9 @@ export function ColorTitle({ name, capitalize, design: designProp, groupId, edit
 
   // ── Render ──
   const rawText = td.text && td.text.trim() ? td.text : name;
-  const display = capitalize ? rawText.toUpperCase() : rawText;
 
   const titleStyle: CSSProperties = {
-    ...roleTextStyle("categoryTitle", "2rem", "display", 700),
+    ...roleTextStyle("categoryTitle", "2rem", "display", 700, capitalize ? "uppercase" : "none"),
     color: td.color || "var(--text)",
     textAlign: td.align || "center",
     lineHeight: 1.05,
@@ -118,7 +117,7 @@ export function ColorTitle({ name, capitalize, design: designProp, groupId, edit
       style={{ backgroundColor: design.bgColor || "var(--surface)", justifyContent: justify }}
     >
       <h2 className="relative z-10 font-display max-w-full" style={titleStyle}>
-        {display}
+        {rawText}
       </h2>
 
       {(design.stickers ?? []).map((s: BannerSticker) => (

--- a/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ImageOverlay.tsx
@@ -8,7 +8,6 @@ export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "
   // `editable` (admin preview); real customers get plain, non-interactive boxes.
   const drag = useBannerFocalDrag(editable, onFocalChange, onFocalCommit);
   if (!imageUrl) return <TextBlock name={name} capitalize={capitalize} />;
-  const display = capitalize ? name.toUpperCase() : name;
   // Dark veil darkness is admin-configurable (0-100). The title keeps its own
   // drop-shadow so it stays legible even when the veil is disabled. With
   // hideTitle (the "image-only" style) we drop both the veil and the title so
@@ -27,9 +26,9 @@ export function ImageOverlay({ name, imageUrl, capitalize, overlay = 40, fit = "
           overall scale apply on top of it while keeping responsiveness. */}
       <h2
         className="font-display text-white font-bold tracking-[0.15em] drop-shadow-[0_2px_8px_rgba(0,0,0,0.5)] [--ctb:1.5rem] sm:[--ctb:1.875rem]"
-        style={roleTextStyle("categoryTitle", "var(--ctb)", "display", 700)}
+        style={roleTextStyle("categoryTitle", "var(--ctb)", "display", 700, capitalize ? "uppercase" : "none")}
       >
-        {display}
+        {name}
       </h2>
       <div className="w-20 sm:w-24 border-t border-white/80 mt-3 sm:mt-4" />
     </div>

--- a/components/themed/CategoryBanner/CategoryBanner.StripedRule.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.StripedRule.tsx
@@ -2,15 +2,14 @@ import type { CategoryBannerProps } from "./CategoryBanner";
 import { roleTextStyle } from "@/lib/themes/typography";
 
 export function StripedRule({ name, capitalize }: CategoryBannerProps) {
-  const display = capitalize ? name.toUpperCase() : name;
   return (
     <div className="px-4 py-5 flex items-center gap-3">
       <div className="flex-1 border-t border-divider" />
       <h2
         className="font-display text-ink font-semibold tracking-wide whitespace-nowrap"
-        style={roleTextStyle("categoryTitle", "1.125rem", "display", 600)}
+        style={roleTextStyle("categoryTitle", "1.125rem", "display", 600, capitalize ? "uppercase" : "none")}
       >
-        {display}
+        {name}
       </h2>
       <div className="flex-1 border-t border-divider" />
     </div>

--- a/components/themed/CategoryBanner/CategoryBanner.TextBlock.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.TextBlock.tsx
@@ -2,7 +2,6 @@ import type { CategoryBannerProps } from "./CategoryBanner";
 import { roleTextStyle } from "@/lib/themes/typography";
 
 export function TextBlock({ name, description, capitalize }: CategoryBannerProps) {
-  const display = capitalize ? name.toUpperCase() : name;
   return (
     <div className="px-4 py-5">
       <h2
@@ -13,12 +12,13 @@ export function TextBlock({ name, description, capitalize }: CategoryBannerProps
             "var(--type-display-lg-size, 2.25rem)",
             "display",
             "var(--type-display-lg-weight, 700)",
+            capitalize ? "uppercase" : "none",
           ),
           lineHeight: "var(--type-display-lg-line, 1.1)",
           letterSpacing: "var(--type-display-lg-tracking, -0.015em)",
         }}
       >
-        {display}
+        {name}
       </h2>
       <div className="mt-2 w-12 border-t border-divider" />
       {description && <p className="mt-2 text-ink-muted text-sm">{description}</p>}

--- a/components/themed/MenuItemCard/MenuItemCard.Compact.tsx
+++ b/components/themed/MenuItemCard/MenuItemCard.Compact.tsx
@@ -19,7 +19,7 @@ export function Compact({ item, currencySymbol, isMostPopular, onClick }: MenuIt
         <div className="flex items-baseline gap-2">
           <h3
             className="font-display text-ink font-semibold truncate"
-            style={roleTextStyle("itemName", "15px", "display", 600)}
+            style={roleTextStyle("itemName", "15px", "display", 600, "none")}
           >
             {itemName}
           </h3>
@@ -39,7 +39,7 @@ export function Compact({ item, currencySymbol, isMostPopular, onClick }: MenuIt
         {itemDescription && (
           <p
             className="text-ink-muted mt-1 line-clamp-2"
-            style={roleTextStyle("itemDescription", "0.875rem", "body", 400)}
+            style={roleTextStyle("itemDescription", "0.875rem", "body", 400, "none")}
           >
             {itemDescription}
           </p>

--- a/components/themed/MenuItemCard/MenuItemCard.Magazine.tsx
+++ b/components/themed/MenuItemCard/MenuItemCard.Magazine.tsx
@@ -24,7 +24,7 @@ export function Magazine({ item, currencySymbol, isMostPopular, onClick }: MenuI
         <div className="flex items-baseline gap-2">
           <h3
             className="font-display text-ink font-semibold flex-1"
-            style={roleTextStyle("itemName", "1.125rem", "display", 600)}
+            style={roleTextStyle("itemName", "1.125rem", "display", 600, "none")}
           >
             {itemName}
           </h3>
@@ -44,7 +44,7 @@ export function Magazine({ item, currencySymbol, isMostPopular, onClick }: MenuI
         {itemDescription && (
           <p
             className="text-ink-muted mt-2 line-clamp-3"
-            style={roleTextStyle("itemDescription", "0.875rem", "body", 400)}
+            style={roleTextStyle("itemDescription", "0.875rem", "body", 400, "none")}
           >
             {itemDescription}
           </p>

--- a/lib/themes/applyTheme.ts
+++ b/lib/themes/applyTheme.ts
@@ -20,6 +20,7 @@ const TYPE_OVERRIDE_VAR_NAMES = [
     `--type-${roleVarSlug(r)}-family`,
     `--type-${roleVarSlug(r)}-size-mult`,
     `--type-${roleVarSlug(r)}-weight`,
+    `--type-${roleVarSlug(r)}-transform`,
   ]),
 ];
 
@@ -50,6 +51,9 @@ function applyTypography(root: HTMLElement, t: TypographyOverrides | null | unde
     }
     if (typeof o.weight === "number" && o.weight >= 100 && o.weight <= 900) {
       root.style.setProperty(`--type-${slug}-weight`, String(o.weight));
+    }
+    if (o.transform === "uppercase" || o.transform === "none") {
+      root.style.setProperty(`--type-${slug}-transform`, o.transform);
     }
   }
   const extraWeights = new Map((t.extraFonts ?? []).map((f) => [f.family, f.weights]));

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -153,7 +153,7 @@ export type PreviewMessage =
       hideNavbarName?: boolean;
       hideHeroLogo?: boolean;
       heroLogoBg?: "white" | "black";
-      heroCoverLayout?: "card" | "logo";
+      heroCoverLayout?: "card" | "logo" | "bare";
       heroLogoSize?: number;
       heroNameFont?: string;
       tagline?: string;

--- a/lib/themes/typography.ts
+++ b/lib/themes/typography.ts
@@ -10,11 +10,14 @@
 //   --type-<role>-family          font-family for that role
 //   --type-<role>-size-mult       per-role size multiplier (unitless)
 //   --type-<role>-weight          font-weight for that role (100-900)
+//   --type-<role>-transform       text-transform ("uppercase" | "none")
 //
 // Effective size = base * --type-scale * --type-<role>-size-mult, so the
 // overall scale and the per-role tweak compose. The component supplies `base`
 // (its current value) as the calc fallback chain's anchor, and its current
 // weight as the weight var's fallback.
+
+import type { CSSProperties } from "react";
 
 export type TypeRoleKey = "categoryTitle" | "itemName" | "itemPrice" | "itemDescription";
 
@@ -27,6 +30,8 @@ export type TypographyRoleOverride = {
   sizeMult?: number;
   /** Font weight (100-900). Absent = keep the component's own weight. */
   weight?: number;
+  /** Text case. Absent = Auto (keep the theme's behavior, e.g. capitalizeBanners). */
+  transform?: "uppercase" | "none";
 };
 
 /** A Google Fonts family the restaurant picked beyond the curated list (the
@@ -72,20 +77,34 @@ export function roleFontFamily(
  *  current font-weight (the value its own classes would apply) — required as
  *  an explicit fallback because the inline style outranks those classes. When
  *  omitted, font-weight is left to the element's classes and the per-role
- *  weight override does not apply. */
+ *  weight override does not apply. Same contract for `baseTransform`: the
+ *  element's current text case (banners derive it from capitalizeBanners);
+ *  when omitted, the per-role case override does not apply. */
+export type RoleTextStyle = {
+  fontFamily: string;
+  fontSize: string;
+  fontWeight?: string;
+  textTransform?: CSSProperties["textTransform"];
+};
+
 export function roleTextStyle(
   role: TypeRoleKey,
   baseSize: string,
   family: "display" | "body" | "inherit" = "display",
   baseWeight?: number | string,
-): { fontFamily: string; fontSize: string; fontWeight?: string } {
+  baseTransform?: "uppercase" | "none",
+): RoleTextStyle {
   const r = roleVarSlug(role);
-  const style: { fontFamily: string; fontSize: string; fontWeight?: string } = {
+  const style: RoleTextStyle = {
     fontFamily: roleFontFamily(role, family),
     fontSize: `calc((${baseSize}) * var(--type-scale, 1) * var(--type-${r}-size-mult, 1))`,
   };
   if (baseWeight !== undefined) {
     style.fontWeight = `var(--type-${r}-weight, ${baseWeight})`;
+  }
+  if (baseTransform !== undefined) {
+    // csstype has no string catch-all for text-transform; the var() is valid CSS.
+    style.textTransform = `var(--type-${r}-transform, ${baseTransform})` as CSSProperties["textTransform"];
   }
   return style;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -552,9 +552,11 @@ export type WebsiteConfig = {
   /**
    * Order-page cover composition. 'card' (default) shows the rounded logo box
    * with the restaurant name and tagline; 'logo' renders the logo on its own,
-   * centered directly on the cover, with no name, tagline or box.
+   * centered directly on the cover, with no name, tagline or box; 'bare'
+   * keeps the logo at the card position (straddling the cover's bottom edge)
+   * but drops the box, name and tagline.
    */
-  heroCoverLayout?: 'card' | 'logo';
+  heroCoverLayout?: 'card' | 'logo' | 'bare';
   /** Scales the cover logo, as a percentage of its default size (100 = default). */
   heroLogoSize?: number;
   /**

--- a/services/api.ts
+++ b/services/api.ts
@@ -226,7 +226,11 @@ export async function fetchRestaurant(idOrSlug: string): Promise<Restaurant> {
       hideNavbarName: data.restaurant.website_config.hide_navbar_name ?? false,
       hideHeroLogo: data.restaurant.website_config.hide_hero_logo ?? false,
       heroLogoBg: data.restaurant.website_config.hero_logo_bg === 'black' ? 'black' : 'white',
-      heroCoverLayout: data.restaurant.website_config.hero_cover_layout === 'logo' ? 'logo' : 'card',
+      heroCoverLayout:
+        data.restaurant.website_config.hero_cover_layout === 'logo' ||
+        data.restaurant.website_config.hero_cover_layout === 'bare'
+          ? data.restaurant.website_config.hero_cover_layout
+          : 'card',
       heroLogoSize: data.restaurant.website_config.hero_logo_size > 0 ? data.restaurant.website_config.hero_logo_size : undefined,
       customPalette: data.restaurant.website_config.custom_palette || undefined,
       sectionColors: data.restaurant.website_config.section_colors || null,


### PR DESCRIPTION
Promotes develop to production:

- feat(hero): bare-logo cover mode — third "Logo sans cadre" cover display option (logo at the card position, no box, name or tagline)
- feat: per-role text case override for menu typography
- fix(order): reorder defaults to first size option for size-less past lines

Counterpart of the foodyadmin promote (PR #129 side) — admin already exposes the third cover option and the Casse control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)