### PR TITLE
feat(website): About section redesign — layouts, readable-over-image, body-typography fix

### DIFF
--- a/components/sections/AboutSection.tsx
+++ b/components/sections/AboutSection.tsx
@@ -88,10 +88,7 @@ function AboutBlockView({ block, settings }: { block: AboutBlock; settings: Reco
                 font_weight: block.title_weight || settings?.font_weight,
               })
           }
-          style={hasTitle ? { fontWeight: 700, ...getFieldStyle(block as Record<string, any>, "title") } : {
-            ...(block.title_color ? { color: block.title_color } : {}),
-            ...(block.title_font ? { fontFamily: `"${block.title_font}", sans-serif` } : {}),
-          }}
+          style={hasTitle ? { fontWeight: 700, ...getFieldStyle(block as Record<string, any>, "title") } : {}}
         >
           {block.title}
         </h2>
@@ -129,7 +126,7 @@ export function AboutSection({ section }: SectionProps) {
     ALIGN_CLASSES.center;
 
   const ctaLabel = (settings.cta_label as string) || "";
-  const ctaLink = (settings.cta_link as string) || "#";
+  const ctaLink = (settings.cta_link as string) || "";
 
   useEffect(() => {
     for (const block of blocks) {
@@ -140,7 +137,7 @@ export function AboutSection({ section }: SectionProps) {
 
   const cta = ctaLabel ? (
     <a
-      href={ctaLink}
+      href={ctaLink || undefined}
       className="inline-block mt-2 px-6 py-3 rounded-full font-semibold bg-[var(--brand)] text-white hover:opacity-90 transition-opacity"
     >
       {ctaLabel}

--- a/components/sections/AboutSection.tsx
+++ b/components/sections/AboutSection.tsx
@@ -8,14 +8,33 @@ import { getSectionBg } from "./sectionBg";
 type AboutBlock = {
   title?: string;
   body?: string;
+  image_url?: string;
   title_color?: string;
   text_color?: string;
   title_font?: string;
-  body_font?: string;
+  text_font?: string;
   title_size?: string;
-  body_size?: string;
+  text_size?: string;
   title_weight?: string;
-  body_weight?: string;
+  text_weight?: string;
+};
+
+const WIDTH_CLASSES: Record<string, string> = {
+  narrow: "max-w-xl",
+  normal: "max-w-3xl",
+  wide: "max-w-5xl",
+};
+
+const PADDING_CLASSES: Record<string, string> = {
+  compact: "py-8",
+  normal: "py-16",
+  spacious: "py-24",
+};
+
+const ALIGN_CLASSES: Record<string, string> = {
+  left: "text-left items-start",
+  center: "text-center items-center",
+  right: "text-right items-end",
 };
 
 /** Migrate legacy {title, body} to blocks format. */
@@ -30,69 +49,137 @@ function getBlocks(content: Record<string, any>): AboutBlock[] {
 }
 
 /**
- * About section supporting multiple title+text blocks.
- * Each block can have individual color, font, size, and weight.
- * Section-level settings control the background color style.
+ * Background for an About section. Unlike other sections, when a background image
+ * is present the darkening overlay defaults ON and text defaults to white, so the
+ * copy stays readable without the owner having to configure anything.
+ */
+function getAboutBg(settings: Record<string, any> | undefined) {
+  const s = settings || {};
+  const hasImg = !!s.bg_image;
+  if (!hasImg) return getSectionBg(s);
+  const overlayOn = s.bg_overlay !== false; // default ON when an image is set
+  const eff = {
+    ...s,
+    bg_overlay: overlayOn,
+    bg_overlay_opacity: s.bg_overlay_opacity ?? 45,
+  };
+  const res = getSectionBg(eff);
+  if (s.color_style !== "custom") {
+    res.style = { ...res.style, color: "#ffffff" };
+  }
+  return res;
+}
+
+/** One title+text(+image) block, with per-block typography overrides. */
+function AboutBlockView({ block, settings }: { block: AboutBlock; settings: Record<string, any> }) {
+  const hasTitle = block.title_color || block.title_font || block.title_size || block.title_weight;
+  const hasBody = block.text_color || block.text_font || block.text_size || block.text_weight;
+  return (
+    <div className="flex flex-col gap-3 w-full">
+      {block.image_url && (
+        <img src={block.image_url} alt="" className="rounded-xl w-full object-cover max-h-80" />
+      )}
+      {block.title && (
+        <h2
+          className={hasTitle
+            ? getFieldSizeClass(block as Record<string, any>, "title", true)
+            : getHeadingClass({
+                heading_size: block.title_size || settings?.heading_size,
+                font_weight: block.title_weight || settings?.font_weight,
+              })
+          }
+          style={hasTitle ? { fontWeight: 700, ...getFieldStyle(block as Record<string, any>, "title") } : {
+            ...(block.title_color ? { color: block.title_color } : {}),
+            ...(block.title_font ? { fontFamily: `"${block.title_font}", sans-serif` } : {}),
+          }}
+        >
+          {block.title}
+        </h2>
+      )}
+      {block.body && (
+        <p
+          className={`${hasBody
+            ? getFieldSizeClass(block as Record<string, any>, "text", false)
+            : getBodyClass({ body_size: block.text_size || settings?.body_size })
+          } opacity-90 whitespace-pre-line`}
+          style={hasBody ? getFieldStyle(block as Record<string, any>, "text") : {}}
+        >
+          {block.body}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * About section with three layouts (centered / split / banner), configurable
+ * alignment, width, spacing, an optional CTA button, and per-block images.
+ * When a background image is set, text is kept readable automatically (see getAboutBg).
  */
 export function AboutSection({ section }: SectionProps) {
   const blocks = getBlocks(section.content);
-  const bg = getSectionBg(section.settings);
+  const settings = section.settings || {};
+  const layout = section.layout === "split" || section.layout === "banner" ? section.layout : "centered";
+  const bg = getAboutBg(settings);
+
+  const width = WIDTH_CLASSES[settings.content_width as string] || WIDTH_CLASSES.normal;
+  const padding = PADDING_CLASSES[settings.padding as string] || PADDING_CLASSES.normal;
+  const align =
+    ALIGN_CLASSES[(settings.text_align as string) || (layout === "split" ? "left" : "center")] ||
+    ALIGN_CLASSES.center;
+
+  const ctaLabel = (settings.cta_label as string) || "";
+  const ctaLink = (settings.cta_link as string) || "#";
 
   useEffect(() => {
     for (const block of blocks) {
       ensureFont(block.title_font);
-      ensureFont(block.body_font);
+      ensureFont(block.text_font);
     }
   }, [blocks]);
 
-  return (
-    <section
-      className={`relative py-16 px-6 ${bg.className}`}
-      style={bg.style}
+  const cta = ctaLabel ? (
+    <a
+      href={ctaLink}
+      className="inline-block mt-2 px-6 py-3 rounded-full font-semibold bg-[var(--brand)] text-white hover:opacity-90 transition-opacity"
     >
-      <div className="relative z-10 max-w-3xl mx-auto text-center flex flex-col gap-8">
-        {blocks.map((block, i) => {
-          const hasTitle = block.title_color || block.title_font || block.title_size || block.title_weight;
-          const hasBody = block.text_color || block.body_font || block.body_size || block.body_weight;
-          return (
-            <div key={i} className="flex flex-col gap-3">
-              {block.title && (
-                <h2
-                  className={hasTitle
-                    ? getFieldSizeClass(block as Record<string, any>, 'title', true)
-                    : getHeadingClass({
-                        heading_size: block.title_size || section.settings?.heading_size,
-                        font_weight: block.title_weight || section.settings?.font_weight,
-                      })
-                  }
-                  style={hasTitle ? { fontWeight: 700, ...getFieldStyle(block as Record<string, any>, 'title') } : {
-                    ...(block.title_color ? { color: block.title_color } : {}),
-                    ...(block.title_font ? { fontFamily: `"${block.title_font}", sans-serif` } : {}),
-                  }}
-                >
-                  {block.title}
-                </h2>
-              )}
-              {block.body && (
-                <p
-                  className={`${hasBody
-                    ? getFieldSizeClass(block as Record<string, any>, 'text', false)
-                    : getBodyClass({
-                        body_size: block.body_size || section.settings?.body_size,
-                      })
-                  } opacity-90 whitespace-pre-line`}
-                  style={hasBody ? getFieldStyle(block as Record<string, any>, 'text') : {
-                    ...(block.text_color ? { color: block.text_color } : {}),
-                    ...(block.body_font ? { fontFamily: `"${block.body_font}", sans-serif` } : {}),
-                    ...(block.body_weight ? { fontWeight: block.body_weight === "bold" ? 700 : block.body_weight === "medium" ? 500 : 400 } : {}),
-                  }}
-                >
-                  {block.body}
-                </p>
-              )}
-            </div>
-          );
-        })}
+      {ctaLabel}
+    </a>
+  ) : null;
+
+  const blockViews = blocks.map((block, i) => (
+    <AboutBlockView key={i} block={block} settings={settings} />
+  ));
+
+  if (layout === "split") {
+    const imageRight = settings.image_side === "right";
+    const img = settings.image_url as string;
+    return (
+      <section className={`relative ${padding} px-6 ${bg.className}`} style={bg.style}>
+        <div className="relative z-10 max-w-6xl mx-auto grid gap-10 md:grid-cols-2 items-center">
+          <div className={imageRight ? "md:order-2" : ""}>
+            {img ? (
+              <img src={img} alt="" className="rounded-2xl w-full object-cover max-h-[28rem]" />
+            ) : (
+              <div className="rounded-2xl w-full aspect-[4/3] bg-black/5" />
+            )}
+          </div>
+          <div className={`flex flex-col gap-6 ${align}`}>
+            {blockViews}
+            {cta}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  // centered + banner share the single-column layout; banner adds min-height.
+  const bannerClass = layout === "banner" ? "min-h-[60vh] flex items-center" : "";
+  return (
+    <section className={`relative ${padding} px-6 ${bannerClass} ${bg.className}`} style={bg.style}>
+      <div className={`relative z-10 ${width} mx-auto flex flex-col gap-8 w-full ${align}`}>
+        {blockViews}
+        {cta}
       </div>
     </section>
   );


### PR DESCRIPTION
## About ("À propos") section redesign — renderer (foodyweb)

Promotes the customer-facing About section changes to production.

- **Readable over background images**: when a bg image is set, the dark scrim defaults ON (opacity 45) and text defaults to white unless custom colors are used. Scoped to About via a local `getAboutBg` — `getSectionBg` and other section types are untouched.
- **Bug fix**: per-block body typography now renders. The renderer read `body_*` keys while the editor writes `text_*`, so body font/size/weight were silently ignored unless a color was also set. Now consistently `text_*`.
- **3 layouts**: centered / split (image beside text) / banner (image behind text).
- Alignment, content width, vertical spacing, optional CTA button, per-block image.

No server/DB changes. Data rides on existing JSONB + the existing `layout` column. Editor counterpart ships in the foodyadmin PR.

Validation: `npm run lint` (clean), `npx tsc --noEmit` (clean), `npm run build` (succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)