### PR TITLE
fix(website): distinct About layouts + drop duplicate custom-page title

### DIFF
--- a/app/r/[restaurantId]/[page]/page.tsx
+++ b/app/r/[restaurantId]/[page]/page.tsx
@@ -49,14 +49,10 @@ export default async function DynamicPage({ params, searchParams }: PageProps) {
       notFound();
     }
 
-    const pageTitle =
-      pageMeta?.label || params.page.charAt(0).toUpperCase() + params.page.slice(1);
-
     return (
       <CustomPageClient
         restaurant={restaurant}
         pageSlug={params.page}
-        pageTitle={pageTitle}
       />
     );
   } catch {

--- a/components/CustomPageClient.tsx
+++ b/components/CustomPageClient.tsx
@@ -18,11 +18,9 @@ import { mapAdminSection, postEditorReady, usePreviewMode } from "@/lib/preview-
 export function CustomPageClient({
   restaurant,
   pageSlug,
-  pageTitle,
 }: {
   restaurant: Restaurant;
   pageSlug: string;
-  pageTitle: string;
 }) {
   const slug = restaurant.slug || String(restaurant.id);
   const previewActive = usePreviewMode();
@@ -78,13 +76,9 @@ export function CustomPageClient({
         </div>
       </nav>
 
-      {/* Page Title */}
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
-        <h1 className="text-3xl font-bold">{pageTitle}</h1>
-      </div>
-
-      {/* Sections */}
-      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+      {/* Sections — each section (e.g. About block titles) carries its own heading;
+          the page name is no longer duplicated as a standalone <h1> here. */}
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-8">
         {pageSections.length > 0 ? (
           <SectionRenderer sections={pageSections} restaurant={restaurant} />
         ) : (

--- a/components/sections/AboutSection.tsx
+++ b/components/sections/AboutSection.tsx
@@ -117,7 +117,10 @@ export function AboutSection({ section }: SectionProps) {
   const blocks = getBlocks(section.content);
   const settings = section.settings || {};
   const layout = section.layout === "split" || section.layout === "banner" ? section.layout : "centered";
-  const bg = getAboutBg(settings);
+  // The full-bleed background image + readable scrim is the Banner layout's defining
+  // trait. Centered and Split use the plain color background so the layouts look
+  // distinct (Centered = text block, Split = image beside text, Banner = image behind).
+  const bg = layout === "banner" ? getAboutBg(settings) : getSectionBg({ ...settings, bg_image: "" });
 
   const width = WIDTH_CLASSES[settings.content_width as string] || WIDTH_CLASSES.normal;
   const padding = PADDING_CLASSES[settings.padding as string] || PADDING_CLASSES.normal;


### PR DESCRIPTION
Follow-up fixes to the About section (renderer), from testing on prod.

- **Centered vs Banner were identical**: the bg image + scrim applied in every layout. Now only **Banner** uses the full-bleed image; **Centered** and **Split** use the plain color background, so the three layouts are visually distinct.
- **Duplicate page title**: custom pages rendered a hardcoded `<h1>` with the page name (e.g. "MAMIE Story") above the sections. Removed it — the About block's own Title is the heading now, which also makes the section-level Heading Size / Font Weight actually apply to it.

Validation: lint (clean), tsc (clean), build (succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)