### PR TITLE
release: promote develop to main (custom font upload)

### DIFF
--- a/components/RestaurantHero.tsx
+++ b/components/RestaurantHero.tsx
@@ -3,6 +3,7 @@
 import { Restaurant, OrderType, BatchFulfillmentConfigResponse, OrderPageBarItem } from "@/lib/types";
 import { useI18n } from "@/lib/i18n";
 import { ensureFont } from "@/components/sections/typography";
+import { injectFontFace } from "@/lib/themes/curatedFonts";
 import { currencySymbol } from "@/lib/constants";
 import { WifiSheet } from "@/components/WifiSheet";
 import { useRestaurantTheme } from "@/lib/restaurant-theme";
@@ -149,12 +150,18 @@ export function RestaurantHero({
   const isLogoCover = websiteConfig?.heroCoverLayout === "logo";
   const isBareLogo = websiteConfig?.heroCoverLayout === "bare";
   const hideBrandText = isLogoCover || isBareLogo;
-  const heroFontWeights = heroNameFont
-    ? websiteConfig?.typography?.extraFonts?.find((f) => f.family === heroNameFont)?.weights
+  const heroExtra = heroNameFont
+    ? websiteConfig?.typography?.extraFonts?.find((f) => f.family === heroNameFont)
     : undefined;
+  const heroFontUrl = heroExtra?.url;
+  const heroFontFormat = heroExtra?.format;
+  const heroFontWeights = heroExtra?.weights;
   useEffect(() => {
-    ensureFont(heroNameFont, heroFontWeights);
-  }, [heroNameFont, heroFontWeights]);
+    if (!heroNameFont) return;
+    // Custom (uploaded) fonts load via @font-face; Google Fonts via css2 link.
+    if (heroFontUrl) injectFontFace(heroNameFont, heroFontUrl, heroFontFormat);
+    else ensureFont(heroNameFont, heroFontWeights);
+  }, [heroNameFont, heroFontUrl, heroFontFormat, heroFontWeights]);
 
   // Mobile cover is kept short so the menu reaches the fold; web gets a taller
   // editorial cover that carries the bottom-left brand overlay.

--- a/lib/themes/applyTheme.ts
+++ b/lib/themes/applyTheme.ts
@@ -1,7 +1,7 @@
 import type { ResolvedTheme } from "./types";
 import { contrastInk } from "./contrastInk";
 import { fontUrlsForPairing } from "./fontUrls";
-import { googleFontUrl } from "./curatedFonts";
+import { googleFontUrl, injectFontFace } from "./curatedFonts";
 import {
   TYPE_ROLE_KEYS,
   roleVarSlug,
@@ -56,9 +56,12 @@ function applyTypography(root: HTMLElement, t: TypographyOverrides | null | unde
       root.style.setProperty(`--type-${slug}-transform`, o.transform);
     }
   }
-  const extraWeights = new Map((t.extraFonts ?? []).map((f) => [f.family, f.weights]));
+  const extras = new Map((t.extraFonts ?? []).map((f) => [f.family, f]));
   for (const family of typographyFontFamilies(t)) {
-    loadFontFamily(family, extraWeights.get(family));
+    const ef = extras.get(family);
+    // Custom (uploaded) fonts load via @font-face; Google Fonts via css2 link.
+    if (ef?.url) injectFontFace(family, ef.url, ef.format);
+    else loadFontFamily(family, ef?.weights);
   }
 }
 

--- a/lib/themes/curatedFonts.ts
+++ b/lib/themes/curatedFonts.ts
@@ -67,6 +67,22 @@ const WEIGHTS_BY_FAMILY: Record<string, number[]> = Object.fromEntries(
   CURATED_FONTS.map((f) => [f.family, f.weights]),
 );
 
+const INJECTED_FACES = new Set<string>();
+
+/** Inject an @font-face for a custom (uploaded) font family (idempotent). Used
+ *  for restaurant fonts that aren't on Google Fonts — the S3 `url` is the source
+ *  and `format` is the CSS format() hint ('woff2' | 'woff' | 'truetype' |
+ *  'opentype'). No-op on the server or for a family already injected. */
+export function injectFontFace(family: string, url: string, format?: string): void {
+  if (typeof document === "undefined" || !family || !url) return;
+  if (INJECTED_FACES.has(family)) return;
+  INJECTED_FACES.add(family);
+  const style = document.createElement("style");
+  const fmt = format ? ` format("${format}")` : "";
+  style.textContent = `@font-face{font-family:"${family}";src:url("${url}")${fmt};font-display:swap;}`;
+  document.head.appendChild(style);
+}
+
 /** Google Fonts css2 stylesheet URL for a family. Curated families use their
  *  declared weights; `extraWeights` (from the restaurant's typography
  *  extraFonts) covers Google Fonts the restaurant picked itself. Falls back to

--- a/lib/themes/typography.ts
+++ b/lib/themes/typography.ts
@@ -34,15 +34,22 @@ export type TypographyRoleOverride = {
   transform?: "uppercase" | "none";
 };
 
-/** A Google Fonts family the restaurant picked beyond the curated list (the
- *  admin font picker persists it automatically). Weights are stored so we can
- *  load the real axes — the css2 fallback for unknown families only fetches
- *  weight 400. */
+/** A font the restaurant added beyond the curated list. Two kinds share this
+ *  shape (the admin font picker persists both automatically):
+ *   - Google Fonts (no `url`): weights are stored so we can load the real axes —
+ *     the css2 fallback for unknown families only fetches weight 400.
+ *   - Custom uploaded fonts (`url` set, `category: 'custom'`): loaded via
+ *     @font-face from the S3 `url` instead of Google Fonts.
+ *  The presence of `url` is the sole discriminator. */
 export type ExtraFont = {
   family: string;
   category: string;
   weights: number[];
   supportsHebrew: boolean;
+  /** Custom-font source (S3). Present ⇒ load via @font-face, not Google Fonts. */
+  url?: string;
+  /** CSS @font-face format() hint: 'woff2' | 'woff' | 'truetype' | 'opentype'. */
+  format?: string;
 };
 
 export type TypographyOverrides = {


### PR DESCRIPTION
Promote develop to production.

Includes the custom-font upload feature (website builder typography) plus everything currently on develop (per release decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)