### PR TITLE
release: drop global menu size scale (per-section sizing only)

### DIFF
--- a/components/themed/CategoryBanner/CategoryBanner.ColorTitle.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ColorTitle.tsx
@@ -105,7 +105,7 @@ export function ColorTitle({ name, capitalize, design: designProp, groupId, edit
     lineHeight: 1.05,
   };
   if (td.font) titleStyle.fontFamily = `"${td.font}", var(--font-display), sans-serif`;
-  if (td.size && td.size !== 1) titleStyle.fontSize = `calc(2rem * var(--type-scale, 1) * ${td.size})`;
+  if (td.size && td.size !== 1) titleStyle.fontSize = `calc(2rem * ${td.size})`;
 
   const justify = td.align === "left" ? "flex-start" : td.align === "right" ? "flex-end" : "center";
 

--- a/lib/themes/applyTheme.ts
+++ b/lib/themes/applyTheme.ts
@@ -15,7 +15,6 @@ const LOADED_FONT_URLS = new Set<string>();
 // can reset them on every apply (overrides are sparse — clearing first avoids a
 // stale var lingering when the admin removes a customization mid-preview).
 const TYPE_OVERRIDE_VAR_NAMES = [
-  "--type-scale",
   ...TYPE_ROLE_KEYS.flatMap((r) => [
     `--type-${roleVarSlug(r)}-family`,
     `--type-${roleVarSlug(r)}-size-mult`,
@@ -38,9 +37,6 @@ function applyTypography(root: HTMLElement, t: TypographyOverrides | null | unde
   for (const name of TYPE_OVERRIDE_VAR_NAMES) root.style.removeProperty(name);
   if (!t) return;
 
-  if (typeof t.sizeScale === "number" && t.sizeScale > 0 && t.sizeScale !== 1) {
-    root.style.setProperty("--type-scale", String(t.sizeScale));
-  }
   for (const role of TYPE_ROLE_KEYS) {
     const o = t.roles?.[role];
     if (!o) continue;

--- a/lib/themes/typography.ts
+++ b/lib/themes/typography.ts
@@ -6,14 +6,12 @@
 // Each role maps to a small set of CSS custom properties that the themed
 // components read with fallbacks, so an absent override renders pixel-identical
 // to today:
-//   --type-scale                  overall size multiplier (unitless)
 //   --type-<role>-family          font-family for that role
 //   --type-<role>-size-mult       per-role size multiplier (unitless)
 //   --type-<role>-weight          font-weight for that role (100-900)
 //   --type-<role>-transform       text-transform ("uppercase" | "none")
 //
-// Effective size = base * --type-scale * --type-<role>-size-mult, so the
-// overall scale and the per-role tweak compose. The component supplies `base`
+// Effective size = base * --type-<role>-size-mult. The component supplies `base`
 // (its current value) as the calc fallback chain's anchor, and its current
 // weight as the weight var's fallback.
 
@@ -65,8 +63,6 @@ export type ExtraFont = {
 };
 
 export type TypographyOverrides = {
-  /** Overall menu text size multiplier. 1 = unchanged. */
-  sizeScale?: number;
   roles?: Partial<Record<TypeRoleKey, TypographyRoleOverride>>;
   /** Non-curated Google Fonts referenced by roles or the hero name font. */
   extraFonts?: ExtraFont[];
@@ -116,7 +112,7 @@ export function roleTextStyle(
   const r = roleVarSlug(role);
   const style: RoleTextStyle = {
     fontFamily: roleFontFamily(role, family),
-    fontSize: `calc((${baseSize}) * var(--type-scale, 1) * var(--type-${r}-size-mult, 1))`,
+    fontSize: `calc((${baseSize}) * var(--type-${r}-size-mult, 1))`,
   };
   if (baseWeight !== undefined) {
     style.fontWeight = `var(--type-${r}-weight, ${baseWeight})`;


### PR DESCRIPTION
Remove the overall menu size multiplier; size is base × per-section only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)