### PR TITLE
feat(checkout): send the customer's display locale with the order

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -583,6 +583,7 @@ function CheckoutContent() {
         customerName: composedCustomerName,
         customerPhone: normalizePhone(customerPhone),
         customerEmail: customerEmail.trim() || undefined,
+        customerLocale: locale,
         deliveryAddress: orderType === "delivery" ? deliveryAddress : undefined,
         deliveryCity: orderType === "delivery" ? deliveryCity : undefined,
         deliveryFloor: orderType === "delivery" ? deliveryFloor : undefined,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -282,6 +282,9 @@ export type OrderPayload = {
   customerPhone?: string;
   // Optional opt-in confirmation email (prefilled from Google sign-in when present)
   customerEmail?: string;
+  // Language the customer is browsing in (he/fr/en). Stored on the order so staff
+  // can message the customer back in their own language.
+  customerLocale?: string;
   deliveryAddress?: string;
   deliveryCity?: string;
   deliveryFloor?: string;

--- a/services/api.ts
+++ b/services/api.ts
@@ -463,6 +463,7 @@ export async function createOrder(payload: OrderPayload): Promise<OrderResponse>
       customer_name: payload.customerName,
       customer_phone: payload.customerPhone,
       customer_email: payload.customerEmail || undefined,
+      customer_locale: payload.customerLocale || undefined,
       delivery_address: payload.deliveryAddress,
       delivery_city: payload.deliveryCity,
       delivery_floor: payload.deliveryFloor,


### PR DESCRIPTION
Sends `customer_locale` with the order so staff can message the customer back in the language they actually ordered in, instead of guessing from the restaurant's default.

Consumed by the WhatsApp order-confirmation recap in the admin order drawer (admin PR #161), and persisted server-side by foodyserver PR #136 (`Order.CustomerLocale`, migration 120).

No visible change for the customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)