### PR TITLE
fix(combo): a step whose items may be repeated is a choice, not a fixed bundle

### DIFF
--- a/components/ComboDetailsModal.tsx
+++ b/components/ComboDetailsModal.tsx
@@ -3,22 +3,10 @@
 import { ComboMenu, ComboCartSelection } from "@/lib/types";
 import { currencySymbol } from "@/lib/constants";
 import { useI18n } from "@/lib/i18n";
+import { isFixedComboShape } from "@/lib/combo/shape";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Image from "next/image";
-
-/** A combo is "fixed" (no customer choice) when every step is either a single
- *  item × N quantity, or a bundle of N items × 1 each. Exported so callers can
- *  branch the entry flow (fixed → add straight to cart, custom → step drawer). */
-export function isFixedComboShape(combo: ComboMenu): boolean {
-  if (combo.steps.length === 0) return false;
-  return combo.steps.every((s) => {
-    if (s.items.length === 0) return false;
-    if (s.minPicks <= 0) return false;
-    if (s.minPicks !== s.maxPicks) return false;
-    return s.items.length === 1 || s.items.length === s.minPicks;
-  });
-}
 
 /** Build the cart selections for a fully-fixed combo (no customer choices). */
 function buildFixedSelections(combo: ComboMenu): ComboCartSelection[] {

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -43,6 +43,7 @@ import {
   batchStepSizePicks,
   normSizeLabel,
 } from "@/lib/combo/batch";
+import { effectivePerItemCap } from "@/lib/combo/shape";
 import { useCartStore } from "@/store/useCartStore";
 import { useTableSession } from "@/store/useTableSession";
 import { createOrder, initSessionPayment, fetchBatchFulfillmentConfig, GuestOrder } from "@/services/api";
@@ -370,8 +371,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
       // Per-item cap: an item may be picked at most N times in the step
       // (across sizes) — an itemLimits override wins over the step default.
       if (step) {
-        const override = step.itemLimits?.find((l) => l.menuItemId === menuItemId);
-        const perItemCap = override ? override.maxQty : step.maxPerItem ?? 0;
+        const perItemCap = effectivePerItemCap(step, menuItemId);
         if (perItemCap > 0) {
           const usedForItem = comboSelections
             .filter((s) => s.stepId === stepId && s.menuItemId === menuItemId)

--- a/lib/combo/__tests__/shape.test.ts
+++ b/lib/combo/__tests__/shape.test.ts
@@ -1,0 +1,129 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { effectivePerItemCap, isFixedComboShape } from "../shape";
+import type { ComboMenu, ComboStep, ComboStepItem } from "../../types";
+
+function item(menuItemId: number): ComboStepItem {
+  return {
+    id: menuItemId * 10,
+    menuItemId,
+    optionId: null,
+    priceDelta: 0,
+    menuItem: { id: menuItemId, name: `Item ${menuItemId}`, price: 0 },
+  };
+}
+
+function step(p: Partial<ComboStep> = {}): ComboStep {
+  return { id: 1, name: "Step", minPicks: 1, maxPicks: 1, sortOrder: 0, items: [], ...p };
+}
+
+function combo(...steps: ComboStep[]): ComboMenu {
+  return { id: 1, name: "Combo", price: 0, isActive: true, sortOrder: 0, steps };
+}
+
+// A group-sourced step resolving to exactly N items, "pick N", is only a fixed
+// bundle when an item cannot be taken twice. This is the SALADS BOX BIG case:
+// 16 salads on the carte, pick 16, up to 2 of the same one — trading one salad
+// for a second copy of another is a real choice, so the customer must get the
+// step builder, not a preset "one of each" list.
+const salads = Array.from({ length: 16 }, (_, i) => item(i + 1));
+
+test("N items / pick N with a per-item cap of 2 is a choice, not a fixed bundle", () => {
+  const c = combo(step({ minPicks: 16, maxPicks: 16, items: salads, maxPerItem: 2 }));
+  assert.equal(isFixedComboShape(c), false);
+});
+
+test("N items / pick N with unlimited repeats is a choice", () => {
+  const c = combo(step({ minPicks: 16, maxPicks: 16, items: salads, maxPerItem: 0 }));
+  assert.equal(isFixedComboShape(c), false);
+});
+
+test("N items / pick N with a per-item cap of 1 is a fixed bundle (one of each)", () => {
+  const c = combo(step({ minPicks: 16, maxPicks: 16, items: salads, maxPerItem: 1 }));
+  assert.equal(isFixedComboShape(c), true);
+});
+
+test("an itemLimits override that permits repeats makes the step a choice", () => {
+  const c = combo(
+    step({
+      minPicks: 16,
+      maxPicks: 16,
+      items: salads,
+      maxPerItem: 1,
+      itemLimits: [{ menuItemId: 3, maxQty: 2 }],
+    }),
+  );
+  assert.equal(isFixedComboShape(c), false);
+});
+
+test("an itemLimits override of 0 (unlimited) makes the step a choice", () => {
+  const c = combo(
+    step({
+      minPicks: 16,
+      maxPicks: 16,
+      items: salads,
+      maxPerItem: 1,
+      itemLimits: [{ menuItemId: 3, maxQty: 0 }],
+    }),
+  );
+  assert.equal(isFixedComboShape(c), false);
+});
+
+test("per-size rules leave the customer a size to pick, so the step is a choice", () => {
+  const c = combo(
+    step({
+      minPicks: 16,
+      maxPicks: 16,
+      items: salads,
+      maxPerItem: 1,
+      variantRules: [
+        { variantLabel: "250g", minPicks: 0, maxPicks: 0 },
+        { variantLabel: "500g", minPicks: 0, maxPicks: 4 },
+      ],
+    }),
+  );
+  assert.equal(isFixedComboShape(c), false);
+});
+
+test("a single item taken N times stays fixed whatever the cap", () => {
+  // One item, 3 picks: there is nothing to decide, and the cap is irrelevant —
+  // no backfill touches this shape.
+  const c = combo(step({ minPicks: 3, maxPicks: 3, items: [item(1)], maxPerItem: 0 }));
+  assert.equal(isFixedComboShape(c), true);
+});
+
+test("more items than picks is always a choice", () => {
+  const c = combo(step({ minPicks: 3, maxPicks: 3, items: salads, maxPerItem: 1 }));
+  assert.equal(isFixedComboShape(c), false);
+});
+
+test("a min/max range is always a choice", () => {
+  const c = combo(step({ minPicks: 1, maxPicks: 16, items: salads, maxPerItem: 1 }));
+  assert.equal(isFixedComboShape(c), false);
+});
+
+test("a combo is fixed only when every step is forced", () => {
+  const forced = step({ id: 1, minPicks: 2, maxPicks: 2, items: [item(1), item(2)], maxPerItem: 1 });
+  const choice = step({ id: 2, minPicks: 1, maxPicks: 1, items: [item(3), item(4)] });
+  assert.equal(isFixedComboShape(combo(forced)), true);
+  assert.equal(isFixedComboShape(combo(forced, choice)), false);
+});
+
+test("a combo with no steps is not a fixed bundle", () => {
+  assert.equal(isFixedComboShape(combo()), false);
+});
+
+test("a step with no resolved items is not a fixed bundle", () => {
+  const c = combo(step({ minPicks: 2, maxPicks: 2, items: [], maxPerItem: 1 }));
+  assert.equal(isFixedComboShape(c), false);
+});
+
+test("effectivePerItemCap: override wins over the step default", () => {
+  const s = step({ items: [item(1), item(2)], maxPerItem: 2, itemLimits: [{ menuItemId: 2, maxQty: 1 }] });
+  assert.equal(effectivePerItemCap(s, 1), 2);
+  assert.equal(effectivePerItemCap(s, 2), 1);
+});
+
+test("effectivePerItemCap: no cap anywhere means unlimited", () => {
+  assert.equal(effectivePerItemCap(step({ items: [item(1)] }), 1), 0);
+});

--- a/lib/combo/shape.ts
+++ b/lib/combo/shape.ts
@@ -1,0 +1,36 @@
+import type { ComboMenu, ComboStep } from "@/lib/types";
+
+/** How many times `menuItemId` may be picked within `step`, counted across all
+ *  its sizes. 0 = unlimited. An itemLimits override wins over the step default. */
+export function effectivePerItemCap(step: ComboStep, menuItemId: number): number {
+  const override = step.itemLimits?.find((l) => l.menuItemId === menuItemId);
+  return override ? override.maxQty : step.maxPerItem ?? 0;
+}
+
+/** True when the step leaves the customer nothing to decide: exactly one basket
+ *  satisfies it. */
+function isStepForced(step: ComboStep): boolean {
+  if (step.items.length === 0) return false;
+  if (step.minPicks <= 0) return false;
+  if (step.minPicks !== step.maxPicks) return false;
+
+  // Per-size rules let the customer pick a size for each item, which is a choice
+  // even when the items themselves are forced.
+  if (step.variantRules && step.variantRules.length > 0) return false;
+
+  // One item, N picks: that item N times. Nothing to decide, cap irrelevant.
+  if (step.items.length === 1) return true;
+
+  // N items, N picks collapses to "one of each" ONLY if an item cannot be taken
+  // twice. As soon as a repeat is allowed the customer can drop one item for a
+  // second copy of another, so the picks are a real decision.
+  if (step.items.length !== step.minPicks) return false;
+  return step.items.every((i) => effectivePerItemCap(step, i.menuItemId) === 1);
+}
+
+/** A combo is "fixed" when no step leaves the customer a choice, so the entry
+ *  flow can add it straight to the cart instead of opening the step builder. */
+export function isFixedComboShape(combo: ComboMenu): boolean {
+  if (combo.steps.length === 0) return false;
+  return combo.steps.every(isStepForced);
+}


### PR DESCRIPTION
Pairs with **server#144**, which must merge first.

Fixes the production report: SALADS BOX BIG is configured as "pick 16 salads from the Salades group, max 2 of the same", but the customer is shown a read-only preset list of 16 salads with no way to choose.

## Root cause

`isFixedComboShape` treated `N items / pick N` as a preset bundle:

```ts
return s.items.length === 1 || s.items.length === s.minPicks;
```

The Salades group resolves to exactly 16 items and the step is `min = max = 16`, so `16 === 16` → "fixed" → the modal rendered the read-only *Whats included* list and `buildFixedSelections` auto-added one of each.

That equivalence only holds if an item cannot be taken twice. With `max_per_item = 2`, trading one salad for a second copy of another is a legitimate basket — there **is** a choice.

The cap was already parsed (`services/api.ts`), typed (`lib/types.ts`), enforced in the builder (`OrderExperience.tsx`) and enforced again server-side at checkout. **Only the gate deciding whether to open the builder was blind to it.**

## Fix

A step is forced only when it leaves nothing to decide: `min = max`, no per-size rules to pick from, and either a single item or an **effective per-item cap of 1** on every item (an `itemLimits` override wins over the step default).

Legacy bundles that leaned on the old shape shortcut get `max_per_item = 1` from the server backfill, so they keep rendering as fixed — no behaviour change for existing combos.

Also: the predicate moves to `lib/combo/shape.ts` so the test runner can reach it (`node --test` only globs `lib/**/__tests__`), and `OrderExperience` drops its hand-rolled copy of the cap lookup for the shared `effectivePerItemCap`.

## Verified

14 new unit tests in `lib/combo/__tests__/shape.test.ts`, written failing first — cap 2 / cap 0 / cap 1 / `itemLimits` overrides / per-size rules / single item × N / more items than picks / min-max range / multi-step / empty.

`npx tsc --noEmit` clean · `npm run lint` clean (pre-existing warnings only) · `npm test` 83/83 · `next build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)