### PR TITLE
Release develop → main: tour banner copy/layout fix

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -307,7 +307,7 @@ function CheckoutContent() {
   // The customer chooses none of this: they read it.
   const tourDayLine = tour ? (
     <p className="mt-2 text-sm text-[var(--text-muted)] text-start">
-      {t("tourDeliveryOn").replace("{date}", formatDateLabel(tour.deliveryDate, locale))}
+      {t("tourDeliveryOn").replace("{date}", formatDateLabel(tour.deliveryDate, locale, { lowerRelative: true }))}
       {tour.deliveryStart && tour.deliveryEnd ? `, ${tour.deliveryStart} - ${tour.deliveryEnd}` : ""}
     </p>
   ) : null;
@@ -1559,7 +1559,7 @@ function CheckoutContent() {
                       <div className="flex items-center gap-2 text-sm font-medium text-brand">
                         <span>📅</span>
                         <span>
-                          {t("tourDeliveryOn")} {formatDateLabel(tour.deliveryDate, locale)}
+                          {t("tourDeliveryOn").replace("{date}", formatDateLabel(tour.deliveryDate, locale, { lowerRelative: true }))}
                           {tour.deliveryStart && tour.deliveryEnd ? `, ${tour.deliveryStart} - ${tour.deliveryEnd}` : ""}
                         </span>
                       </div>

--- a/components/TourBanner.tsx
+++ b/components/TourBanner.tsx
@@ -24,27 +24,27 @@ type Props = {
 export function TourBanner({ tour, isActive, onSelect }: Props) {
   const { t, locale } = useI18n();
 
-  const day = formatDateLabel(tour.deliveryDate, locale);
+  const day = formatDateLabel(tour.deliveryDate, locale, { lowerRelative: true });
   const slot =
     tour.deliveryStart && tour.deliveryEnd ? `${tour.deliveryStart} - ${tour.deliveryEnd}` : null;
-  const cutoff = formatCutoffLabel(tour.cutoffAt, locale);
-  const cities = tour.cities.join(", ");
+  const cutoff = formatCutoffLabel(tour.cutoffAt, locale, { lowerRelative: true });
 
   return (
     <div
-      className="mx-4 mt-4 rounded-2xl border p-4 flex flex-wrap items-center gap-3"
+      className="mx-4 mt-4 rounded-2xl border p-4 flex flex-wrap items-center gap-x-4 gap-y-3"
       style={{
         background: "color-mix(in srgb, var(--brand) 8%, transparent)",
         borderColor: "color-mix(in srgb, var(--brand) 30%, transparent)",
       }}
     >
+      {/* Title already names the city (a tour is named for it), so the body
+          states the day/slot and cutoff only — no redundant city line. */}
       <div className="flex-1 min-w-[14rem] text-start">
         <p className="font-bold text-[var(--text)] flex items-center gap-2">
           <span aria-hidden="true">🚚</span>
           <span>{tour.name}</span>
         </p>
         <p className="text-sm text-[var(--text)] opacity-80 mt-1">
-          {cities ? `${cities} · ` : ""}
           {t("tourDeliveryOn").replace("{date}", day)}
           {slot ? `, ${slot}` : ""}
         </p>
@@ -52,14 +52,16 @@ export function TourBanner({ tour, isActive, onSelect }: Props) {
           {t("tourOrdersClose")} {cutoff}
         </p>
       </div>
-      <button
-        onClick={onSelect}
-        aria-current={isActive ? "true" : undefined}
-        className="px-4 py-2 rounded-full text-sm font-semibold text-white whitespace-nowrap hover:opacity-90 transition-opacity"
-        style={{ background: "var(--brand)" }}
-      >
-        {t("tourBannerCta")}
-      </button>
+      {/* The CTA switches to the tour carte; pointless when it's already shown. */}
+      {!isActive && (
+        <button
+          onClick={onSelect}
+          className="shrink-0 px-5 py-2.5 rounded-full text-sm font-semibold text-white whitespace-nowrap hover:opacity-90 transition-opacity"
+          style={{ background: "var(--brand)" }}
+        >
+          {t("tourBannerCta")}
+        </button>
+      )}
     </div>
   );
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -197,7 +197,7 @@ const translations: Record<Locale, Record<string, string>> = {
     tourOrdersClose: "Orders close",
     // Carries its own date placeholder: Hebrew glues the preposition to the date
     // ("משלוח ב-17 ביולי"), so the day cannot be appended by the caller.
-    tourDeliveryOn: "Delivery on {date}",
+    tourDeliveryOn: "Delivery {date}",
     tourSwitchCartTitle: "Empty your cart?",
     tourSwitchCartBody: "Your cart holds items from another carte. Tour orders ship on their own day, so they cannot be mixed.",
     tourSwitchCartConfirm: "Empty and continue",
@@ -692,7 +692,7 @@ const translations: Record<Locale, Record<string, string>> = {
     tourBannerCta: "לצפייה בתפריט",
     tourOrdersClose: "סגירת הזמנות",
     // The "ב-" prefix must touch the date: "משלוח ב-17 ביולי", never "ב- 17".
-    tourDeliveryOn: "משלוח ב-{date}",
+    tourDeliveryOn: "משלוח {date}",
     tourSwitchCartTitle: "לרוקן את העגלה?",
     tourSwitchCartBody: "בעגלה יש פריטים מתפריט אחר. הזמנות סבב יוצאות ביום נפרד ולכן אי אפשר לערבב.",
     tourSwitchCartConfirm: "רוקן והמשך",
@@ -1183,7 +1183,7 @@ const translations: Record<Locale, Record<string, string>> = {
     reorderUnavailable: "Absent du menu de cette semaine, ignoré : {list}",
     tourBannerCta: "Voir la carte",
     tourOrdersClose: "Commandes jusqu'à",
-    tourDeliveryOn: "Livraison le {date}",
+    tourDeliveryOn: "Livraison {date}",
     tourSwitchCartTitle: "Vider votre panier ?",
     tourSwitchCartBody: "Votre panier contient des articles d'une autre carte. Une commande de tournée part un jour à part, elle ne peut pas être mélangée.",
     tourSwitchCartConfirm: "Vider et continuer",

--- a/lib/scheduling.ts
+++ b/lib/scheduling.ts
@@ -30,15 +30,23 @@ function localeTag(locale: Locale): string {
  * Returns a human-readable label for a "YYYY-MM-DD" date string, localised to
  * `locale`: "Today", "Tomorrow", or e.g. "Mon, Feb 26" / "lun. 26 févr.".
  */
-export function formatDateLabel(dateStr: string, locale: Locale = "en"): string {
+export function formatDateLabel(
+  dateStr: string,
+  locale: Locale = "en",
+  opts?: { lowerRelative?: boolean }
+): string {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const tomorrow = new Date(today);
   tomorrow.setDate(tomorrow.getDate() + 1);
   const d = new Date(dateStr + "T00:00:00");
   const relative = RELATIVE_DAY_LABELS[locale] ?? RELATIVE_DAY_LABELS.en;
-  if (d.getTime() === today.getTime()) return relative.today;
-  if (d.getTime() === tomorrow.getTime()) return relative.tomorrow;
+  // Relative words ("Today"/"Aujourd'hui") are capitalised for standalone use
+  // (date chips). Inside a phrase ("Delivery today", "Livraison aujourd'hui")
+  // they must be lowercased; weekday forms below are left untouched.
+  const rel = (s: string) => (opts?.lowerRelative ? s.toLocaleLowerCase(localeTag(locale)) : s);
+  if (d.getTime() === today.getTime()) return rel(relative.today);
+  if (d.getTime() === tomorrow.getTime()) return rel(relative.tomorrow);
   return d.toLocaleDateString(localeTag(locale), { weekday: "short", month: "short", day: "numeric" });
 }
 
@@ -48,7 +56,11 @@ export function formatDateLabel(dateStr: string, locale: Locale = "en"): string 
  * instant (not a calendar day) and is very often today or tomorrow: a round is
  * routinely opened at 11am for the same evening.
  */
-export function formatCutoffLabel(iso: string, locale: Locale = "en"): string {
+export function formatCutoffLabel(
+  iso: string,
+  locale: Locale = "en",
+  opts?: { lowerRelative?: boolean }
+): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "";
   // Local calendar day of the instant — NOT `toISOString().slice(0, 10)`, which
@@ -57,7 +69,7 @@ export function formatCutoffLabel(iso: string, locale: Locale = "en"): string {
     d.getDate()
   ).padStart(2, "0")}`;
   const time = d.toLocaleTimeString(localeTag(locale), { hour: "2-digit", minute: "2-digit" });
-  return `${formatDateLabel(dateStr, locale)} ${time}`;
+  return `${formatDateLabel(dateStr, locale, opts)} ${time}`;
 }
 
 /** Returns the localised full weekday name (e.g. "Friday" / "vendredi") for a "YYYY-MM-DD" date. */


### PR DESCRIPTION
UI polish on the delivery-tour banner (reported on prod):
- French grammar: "Livraison le Aujourd'hui" → "Livraison aujourd'hui"; "jusqu'à Aujourd'hui" → "jusqu'à aujourd'hui". Relative-day words keep their capital for standalone date chips but lose the preposition + capital inside a phrase (new `lowerRelative` option).
- Fix a checkout line that rendered the literal `{date}` placeholder (missing `.replace`).
- Drop the redundant city line (the title already names the tour after its city).
- Hide the "See the carte" CTA when that carte is already shown.

foodyweb only. tsc + lint + next build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)