### PR TITLE
Release develop → main: theme the dedicated tour page

### DIFF
--- a/lib/themes/useResolvedTheme.tsx
+++ b/lib/themes/useResolvedTheme.tsx
@@ -61,7 +61,7 @@ function hexToRgba(hex: string, alpha: number): string {
 // at the edge, so usePathname() returns the public path without it. Match
 // both forms or themed pages render with light :root defaults on those hosts.
 const ORDER_ROUTE_RE =
-  /(?:\/r\/[^/]+\/(?:order(?:\/|$|\?)|table(?:\/|$|\?)|t\/))|(?:^\/order(?:\/|$|\?))|(?:^\/table(?:\/|$|\?))|(?:^\/t\/)/;
+  /(?:\/r\/[^/]+\/(?:order(?:\/|$|\?)|table(?:\/|$|\?)|tournee(?:\/|$|\?)|t\/))|(?:^\/order(?:\/|$|\?))|(?:^\/table(?:\/|$|\?))|(?:^\/tournee(?:\/|$|\?))|(?:^\/t\/)/;
 function isOrderRoute(pathname: string | null): boolean {
   if (!pathname) return false;
   return ORDER_ROUTE_RE.test(pathname);


### PR DESCRIPTION
Prod fix: the dedicated tour page `/r/<slug>/tournee/<slug>` rendered with light defaults (white background) instead of the restaurant's theme, because the theme system only applies its CSS vars on recognised order routes and `tournee` was not in the allowlist. Added it (both `/r/<slug>/` and custom-domain `/tournee/` forms). Non-regression verified: `/order` still matches, the landing route stays excluded.

foodyweb only, one-line regex change. tsc + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)