### PR TITLE
design(tours): redesign the tour banner as a departure card

### DIFF
--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -150,6 +150,22 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
     if (cart.canAdd(activeTour.id)) cart.setTour(activeTour.id, activeTour.slug);
   }, [activeTour]);
 
+  // The mirror of the bind above. That bind fires on mere ARRIVAL at a tour link
+  // — before the guest adds anything — and it is persisted to localStorage. So a
+  // guest who opened a round and left with an empty cart still carries its id.
+  // That stale binding must not follow them off the tour page: at a table it
+  // trips the "tour cart here" refusal, at checkout it forces delivery, and on
+  // the normal site it froze the order type (mode chip read-only, no pickup —
+  // the "stuck on Livraison" bug). An empty cart has no lines to protect, so
+  // drop the binding once we are off the tour page (no `activeTour`) with an
+  // empty cart. Never runs on the tour page, which keeps its binding.
+  useEffect(() => {
+    if (activeTour) return;
+    if (cartTourId && lines.length === 0) {
+      useCartStore.getState().setTour(undefined, undefined);
+    }
+  }, [activeTour, cartTourId, lines.length]);
+
   // An add parked on the guest's answer to "empty your cart?".
   const [pendingTourAdd, setPendingTourAdd] = useState<{
     tourId: number | undefined;
@@ -193,7 +209,12 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
   // A tour cart is a delivery round, and the checkout already forces it to
   // `delivery`. The menu page must say the same thing: no pickup/delivery
   // switch, no order-details modal, no scheduling — the tour fixed all three.
-  const isTourCart = !!cartTourId && !isTableOrder;
+  // A binding only means "tour cart" once there are lines to protect, or while
+  // the guest is actually on the tour page (`activeTour`), where delivery is the
+  // whole point. Off the tour page with an empty cart the binding is stale (the
+  // shed effect above clears it), NOT a tour cart — keying on `!!cartTourId`
+  // alone is what let a leftover round freeze the normal site in delivery.
+  const isTourCart = !isTableOrder && !!cartTourId && (lines.length > 0 || !!activeTour);
 
   /**
    * A tour cart at a table: only reachable with a cart built on the delivery site

--- a/components/TourBanner.tsx
+++ b/components/TourBanner.tsx
@@ -9,13 +9,13 @@ type Props = {
 };
 
 /**
- * Header strip for a delivery tour on its dedicated page.
+ * Header for a delivery tour's dedicated page.
  *
- * A tour is a one-off round to a city the restaurant does not normally serve,
- * reachable only through its dedicated link. The customer arriving there sees
- * ONLY this round's carte, so the strip is no longer a discovery tab — it is the
- * page header, stating the city (the tour is named for it), the delivery day and
- * slot, and the order cutoff.
+ * A tour is a one-off delivery run to a city the restaurant does not normally
+ * serve, reached only through its own link. This strip is the whole context the
+ * customer lands with, so it announces the run like a small departure card: the
+ * destination as the headline (in the restaurant's display face), then the two
+ * facts that matter — when it arrives, and by when to order.
  */
 export function TourBanner({ tour }: Props) {
   const { t, locale } = useI18n();
@@ -26,26 +26,59 @@ export function TourBanner({ tour }: Props) {
   const cutoff = formatCutoffLabel(tour.cutoffAt, locale, { lowerRelative: true });
 
   return (
-    <div
-      className="mx-4 mt-4 rounded-2xl border p-4 text-start"
+    <section
+      aria-label={tour.name}
+      className="mx-4 mt-4 flex overflow-hidden rounded-2xl text-start"
       style={{
-        background: "color-mix(in srgb, var(--brand) 8%, transparent)",
-        borderColor: "color-mix(in srgb, var(--brand) 30%, transparent)",
+        background: "var(--surface-elevated)",
+        boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--brand) 20%, transparent)",
       }}
     >
-      {/* Title already names the city (a tour is named for it), so the body
-          states the day/slot and cutoff only — no redundant city line. */}
-      <p className="font-bold text-[var(--text)] flex items-center gap-2">
-        <span aria-hidden="true">🚚</span>
-        <span>{tour.name}</span>
-      </p>
-      <p className="text-sm text-[var(--text)] opacity-80 mt-1">
-        {t("tourDeliveryOn").replace("{date}", day)}
-        {slot ? `, ${slot}` : ""}
-      </p>
-      <p className="text-xs text-[var(--text)] opacity-70 mt-0.5">
-        {t("tourOrdersClose")} {cutoff}
-      </p>
-    </div>
+      {/* Brand rail: this run, heading to its destination. */}
+      <span aria-hidden="true" className="w-1.5 shrink-0" style={{ background: "var(--brand)" }} />
+
+      <div className="flex-1 p-4 sm:p-5">
+        <p
+          className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em]"
+          style={{ color: "var(--brand)" }}
+        >
+          <span aria-hidden="true">🚚</span>
+          {t("tourEyebrow")}
+        </p>
+
+        <h2
+          className="mt-1.5 text-2xl font-bold leading-tight sm:text-3xl"
+          style={{ color: "var(--text)", fontFamily: "var(--font-display)" }}
+        >
+          {tour.name}
+        </h2>
+
+        <dl className="mt-3.5 grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-6">
+          <div>
+            <dt
+              className="text-[11px] font-semibold uppercase tracking-wide"
+              style={{ color: "var(--text-soft)" }}
+            >
+              {t("delivery")}
+            </dt>
+            <dd className="mt-0.5 text-sm font-medium" style={{ color: "var(--text)" }}>
+              {day}
+              {slot ? <span style={{ color: "var(--text-muted)" }}> · {slot}</span> : null}
+            </dd>
+          </div>
+          <div>
+            <dt
+              className="text-[11px] font-semibold uppercase tracking-wide"
+              style={{ color: "var(--text-soft)" }}
+            >
+              {t("tourOrderByLabel")}
+            </dt>
+            <dd className="mt-0.5 text-sm font-medium" style={{ color: "var(--text)" }}>
+              {cutoff}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </section>
   );
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -195,6 +195,8 @@ const translations: Record<Locale, Record<string, string>> = {
     // serve, on a given day, off its own carte.
     tourBannerCta: "See the carte",
     tourOrdersClose: "Orders close",
+    tourEyebrow: "Delivery run",
+    tourOrderByLabel: "Order by",
     // Carries its own date placeholder: Hebrew glues the preposition to the date
     // ("משלוח ב-17 ביולי"), so the day cannot be appended by the caller.
     tourDeliveryOn: "Delivery {date}",
@@ -697,6 +699,8 @@ const translations: Record<Locale, Record<string, string>> = {
     reorderUnavailable: "לא בתפריט השבוע, אז דילגנו: {list}",
     tourBannerCta: "לצפייה בתפריט",
     tourOrdersClose: "סגירת הזמנות",
+    tourEyebrow: "סבב משלוח",
+    tourOrderByLabel: "להזמין עד",
     // The "ב-" prefix must touch the date: "משלוח ב-17 ביולי", never "ב- 17".
     tourDeliveryOn: "משלוח {date}",
     tourSwitchCartTitle: "לרוקן את העגלה?",
@@ -1193,6 +1197,8 @@ const translations: Record<Locale, Record<string, string>> = {
     reorderUnavailable: "Absent du menu de cette semaine, ignoré : {list}",
     tourBannerCta: "Voir la carte",
     tourOrdersClose: "Commandes jusqu'à",
+    tourEyebrow: "Tournée",
+    tourOrderByLabel: "Commander avant",
     tourDeliveryOn: "Livraison {date}",
     tourSwitchCartTitle: "Vider votre panier ?",
     tourSwitchCartBody: "Votre panier contient des articles d'une autre carte. Une commande de tournée part un jour à part, elle ne peut pas être mélangée.",


### PR DESCRIPTION
The banner was a flat tinted box. Reframe it as the announcement of a delivery run: an eyebrow ("Tournée"), the destination city as the headline in the restaurant's display face, a brand rail down the start edge, and the two facts that matter as a small schedule — Livraison (day + window) and Commander avant (cutoff, active voice instead of the passive "Commandes jusqu'à"). All theme tokens (--brand, --surface-elevated, --text*, --font-display), RTL-aware.