### PR TITLE
feat(website): separate category-banner text color from body text

### DIFF
--- a/components/themed/CategoryBanner/CategoryBanner.ColorTitle.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.ColorTitle.tsx
@@ -100,7 +100,7 @@ export function ColorTitle({ name, capitalize, design: designProp, groupId, edit
 
   const titleStyle: CSSProperties = {
     ...roleTextStyle("categoryTitle", "2rem", "display", 700, capitalize ? "uppercase" : "none"),
-    color: td.color || "var(--text)",
+    color: td.color || "var(--cat-heading, var(--text))",
     textAlign: td.align || "center",
     lineHeight: 1.05,
   };

--- a/components/themed/CategoryBanner/CategoryBanner.StripedRule.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.StripedRule.tsx
@@ -6,8 +6,11 @@ export function StripedRule({ name, capitalize }: CategoryBannerProps) {
     <div className="px-4 py-5 flex items-center gap-3">
       <div className="flex-1 border-t border-divider" />
       <h2
-        className="font-display text-ink font-semibold tracking-wide whitespace-nowrap"
-        style={roleTextStyle("categoryTitle", "1.125rem", "display", 600, capitalize ? "uppercase" : "none")}
+        className="font-display font-semibold tracking-wide whitespace-nowrap"
+        style={{
+          ...roleTextStyle("categoryTitle", "1.125rem", "display", 600, capitalize ? "uppercase" : "none"),
+          color: "var(--cat-heading, var(--text))",
+        }}
       >
         {name}
       </h2>

--- a/components/themed/CategoryBanner/CategoryBanner.TextBlock.tsx
+++ b/components/themed/CategoryBanner/CategoryBanner.TextBlock.tsx
@@ -5,7 +5,7 @@ export function TextBlock({ name, description, capitalize }: CategoryBannerProps
   return (
     <div className="px-4 py-5">
       <h2
-        className="font-display text-ink"
+        className="font-display"
         style={{
           ...roleTextStyle(
             "categoryTitle",
@@ -14,6 +14,7 @@ export function TextBlock({ name, description, capitalize }: CategoryBannerProps
             "var(--type-display-lg-weight, 700)",
             capitalize ? "uppercase" : "none",
           ),
+          color: "var(--cat-heading, var(--text))",
           lineHeight: "var(--type-display-lg-line, 1.1)",
           letterSpacing: "var(--type-display-lg-tracking, -0.015em)",
         }}

--- a/lib/themes/applyTheme.ts
+++ b/lib/themes/applyTheme.ts
@@ -107,6 +107,9 @@ function legacyVarsFromTheme(rt: ResolvedTheme): LegacyVarMap {
     "--text-muted": c.inkMuted,
     "--text-soft": c.inkSoft,
     "--ink-on-accent": accentInk,
+    // Category banner/divider text — decoupled from body text so a custom
+    // palette can set it independently; falls back to ink for built-in themes.
+    "--cat-heading": c.categoryInk ?? c.ink,
     // Surfaces.
     "--surface": c.surface,
     "--surface-subtle": c.surfaceMuted,
@@ -168,7 +171,7 @@ export function applyTheme(rt: ResolvedTheme): void {
 
 const LEGACY_VAR_NAMES = [
   "--brand", "--brand-rgb", "--brand-dark", "--brand-light", "--price",
-  "--text", "--text-muted", "--text-soft", "--ink-on-accent",
+  "--text", "--text-muted", "--text-soft", "--ink-on-accent", "--cat-heading",
   "--surface", "--surface-subtle", "--surface-elevated",
   "--bg-page", "--bg-muted", "--divider",
   "--success", "--warning", "--error",

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -23,6 +23,9 @@ export type ColorTokens = {
   success: string;
   warning: string;
   error: string;
+  /** Text color for category banners/dividers. Only the custom palette sets it;
+   *  built-in themes leave it unset and category text falls back to `ink`. */
+  categoryInk?: string;
 };
 
 export type RadiusTokens = {
@@ -167,6 +170,7 @@ export type PreviewMessage =
         surface: string;
         accent: string;
         ink: string;
+        categoryInk?: string;
       } | null;
       sectionColors?: import("@/lib/types").SectionColors | null;
       faviconURL?: string;

--- a/lib/themes/useResolvedTheme.tsx
+++ b/lib/themes/useResolvedTheme.tsx
@@ -33,6 +33,8 @@ function buildCustomTheme(p: CustomPalette): typeof themesById[string] {
         inkMuted: shade(p.ink, isDark ? -0.18 : 0.36),
         inkSoft: shade(p.ink, isDark ? -0.36 : 0.55),
         divider: hexToRgba(p.ink, 0.14),
+        // Category-banner text: an explicit swatch, else inherit the body ink.
+        categoryInk: p.categoryInk || p.ink,
         accent: p.accent,
         accentInk: contrastInk(p.accent),
         success: isDark ? "#88B26A" : "#3A8050",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -664,6 +664,9 @@ export type WebsiteConfig = {
     surface: string;
     accent: string;
     ink: string;
+    /** Text color for category banners/dividers. Optional — falls back to `ink`
+     *  so existing palettes render identically until an owner sets it. */
+    categoryInk?: string;
   };
   /** Optional per-section color overrides layered on top of the active theme.
    *  Any missing section/field inherits the global theme color. */


### PR DESCRIPTION
## What
Splits the custom-palette **Text** swatch into two independent colors: body/card
text keeps the existing swatch, and category banner/divider titles get a new
**Category text** swatch.

## Why
Setting the palette Text color (e.g. white, for a colored category banner) also
whitened the product-card text on the white card surface — the two surfaces
shared one color and couldn't both stay legible.

## How
- **server**: optional `categoryInk` on the custom-palette payload, validated only when set.
- **web**: new `--cat-heading` CSS var (`categoryInk`, falling back to `ink`); only the category banner variants read it, cards stay on `--text`.
- **admin**: 5th palette swatch ("Category text" / "Texte des catégories"), shown inheriting Text until customized.

## Backward compatibility
`--cat-heading` / `categoryInk` default to the existing text color, so every
current site renders identically until an owner sets the new swatch. No DB
migration (palette is a JSON blob).

## Scope
Isolated hotfix off `main` (cherry-picked from `develop`), so only this change
ships to production — not the rest of `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
