### PR TITLE
feat(web): search-field + item-detail-modal palette colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -305,7 +305,7 @@ body {
 /* Search input */
 .search-input {
   @apply flex items-center gap-2 px-4 py-2.5 rounded-full;
-  background: var(--surface-subtle);
+  background: var(--search-bg, var(--surface-subtle));
 }
 
 .search-input input {

--- a/app/globals.css
+++ b/app/globals.css
@@ -317,6 +317,19 @@ body {
   color: var(--text-soft);
 }
 
+/* Item/combo detail modals ("fiches") scope their text tiers to the menu-text
+   swatch. --menu-text* are always emitted (falling back to the ink tiers), so
+   this is identical to the global text until an owner sets the swatch. Fixes the
+   modal's previously-undefined --text-primary/--text-secondary along the way. */
+.carte-text {
+  color: var(--menu-text);
+  --text: var(--menu-text);
+  --text-primary: var(--menu-text);
+  --text-secondary: var(--menu-text-muted);
+  --text-muted: var(--menu-text-muted);
+  --text-soft: var(--menu-text-soft);
+}
+
 /* Install prompt slide-up animation */
 @keyframes slide-up {
   from { transform: translateY(100%); opacity: 0; }

--- a/components/ComboDetailsModal.tsx
+++ b/components/ComboDetailsModal.tsx
@@ -112,7 +112,7 @@ export function ComboDetailsModal({
             animate={{ y: 0, opacity: 1, scale: 1 }}
             exit={{ y: 48, opacity: 0, scale: 0.97 }}
             transition={{ type: "spring", damping: 26, stiffness: 320 }}
-            className="w-full sm:max-w-md rounded-t-3xl sm:rounded-3xl bg-[var(--surface-elevated)] overflow-hidden shadow-2xl flex flex-col max-h-[92vh]"
+            className="carte-text w-full sm:max-w-md rounded-t-3xl sm:rounded-3xl bg-[var(--surface-elevated)] overflow-hidden shadow-2xl flex flex-col max-h-[92vh]"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Hero image — kept compact (and capped against the viewport) so

--- a/components/ItemModal.tsx
+++ b/components/ItemModal.tsx
@@ -412,7 +412,7 @@ export function ItemModal({ item, restaurantName, onClose, onAdd }: Props) {
             }}
             onPointerDown={maybeStartDrag}
             onClick={(e) => e.stopPropagation()}
-            className="relative bg-[var(--surface)] w-full sm:max-w-lg sm:rounded-3xl overflow-hidden shadow-2xl flex flex-col h-[100dvh] sm:h-auto sm:max-h-[92vh]"
+            className="carte-text relative bg-[var(--surface)] w-full sm:max-w-lg sm:rounded-3xl overflow-hidden shadow-2xl flex flex-col h-[100dvh] sm:h-auto sm:max-h-[92vh]"
             dir={direction}
           >
             {/* Drag handle — visible affordance AND a generous always-drag

--- a/lib/themes/applyTheme.ts
+++ b/lib/themes/applyTheme.ts
@@ -113,6 +113,9 @@ function legacyVarsFromTheme(rt: ResolvedTheme): LegacyVarMap {
     // Surfaces.
     "--surface": c.surface,
     "--surface-subtle": c.surfaceMuted,
+    // Search field fill — decoupled from Surface so it can be set independently;
+    // falls back to the muted surface the field uses today.
+    "--search-bg": c.searchBg ?? c.surfaceMuted,
     "--surface-elevated": shade(c.surface, rt.theme.mode === "dark" ? 0.08 : -0.03),
     "--bg-page": c.bg,
     "--bg-muted": c.surfaceMuted,
@@ -172,7 +175,7 @@ export function applyTheme(rt: ResolvedTheme): void {
 const LEGACY_VAR_NAMES = [
   "--brand", "--brand-rgb", "--brand-dark", "--brand-light", "--price",
   "--text", "--text-muted", "--text-soft", "--ink-on-accent", "--cat-heading",
-  "--surface", "--surface-subtle", "--surface-elevated",
+  "--surface", "--surface-subtle", "--search-bg", "--surface-elevated",
   "--bg-page", "--bg-muted", "--divider",
   "--success", "--warning", "--error",
 ];

--- a/lib/themes/applyTheme.ts
+++ b/lib/themes/applyTheme.ts
@@ -110,6 +110,11 @@ function legacyVarsFromTheme(rt: ResolvedTheme): LegacyVarMap {
     // Category banner/divider text — decoupled from body text so a custom
     // palette can set it independently; falls back to ink for built-in themes.
     "--cat-heading": c.categoryInk ?? c.ink,
+    // Item/combo detail-modal text tiers — the .carte-text scope repoints the
+    // modal's text vars at these; fall back to the ink tiers for built-in themes.
+    "--menu-text": c.menuText ?? c.ink,
+    "--menu-text-muted": c.menuTextMuted ?? c.inkMuted,
+    "--menu-text-soft": c.menuTextSoft ?? c.inkSoft,
     // Surfaces.
     "--surface": c.surface,
     "--surface-subtle": c.surfaceMuted,
@@ -175,6 +180,7 @@ export function applyTheme(rt: ResolvedTheme): void {
 const LEGACY_VAR_NAMES = [
   "--brand", "--brand-rgb", "--brand-dark", "--brand-light", "--price",
   "--text", "--text-muted", "--text-soft", "--ink-on-accent", "--cat-heading",
+  "--menu-text", "--menu-text-muted", "--menu-text-soft",
   "--surface", "--surface-subtle", "--search-bg", "--surface-elevated",
   "--bg-page", "--bg-muted", "--divider",
   "--success", "--warning", "--error",

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -26,6 +26,9 @@ export type ColorTokens = {
   /** Text color for category banners/dividers. Only the custom palette sets it;
    *  built-in themes leave it unset and category text falls back to `ink`. */
   categoryInk?: string;
+  /** Background fill of the search field. Only the custom palette sets it;
+   *  built-in themes leave it unset and the field falls back to surfaceMuted. */
+  searchBg?: string;
 };
 
 export type RadiusTokens = {
@@ -171,6 +174,7 @@ export type PreviewMessage =
         accent: string;
         ink: string;
         categoryInk?: string;
+        searchBg?: string;
       } | null;
       sectionColors?: import("@/lib/types").SectionColors | null;
       faviconURL?: string;

--- a/lib/themes/types.ts
+++ b/lib/themes/types.ts
@@ -29,6 +29,11 @@ export type ColorTokens = {
   /** Background fill of the search field. Only the custom palette sets it;
    *  built-in themes leave it unset and the field falls back to surfaceMuted. */
   searchBg?: string;
+  /** Text tiers for item/combo detail modals ("fiches"). Only the custom palette
+   *  sets them; built-in themes fall back to the ink tiers. */
+  menuText?: string;
+  menuTextMuted?: string;
+  menuTextSoft?: string;
 };
 
 export type RadiusTokens = {
@@ -175,6 +180,7 @@ export type PreviewMessage =
         ink: string;
         categoryInk?: string;
         searchBg?: string;
+        menuText?: string;
       } | null;
       sectionColors?: import("@/lib/types").SectionColors | null;
       faviconURL?: string;

--- a/lib/themes/useResolvedTheme.tsx
+++ b/lib/themes/useResolvedTheme.tsx
@@ -18,6 +18,7 @@ type CustomPalette = NonNullable<WebsiteConfig["customPalette"]>;
 function buildCustomTheme(p: CustomPalette): typeof themesById[string] {
   const isDark = p.mode === "dark";
   const base = isDark ? themesById["editorial-dark"] : themesById["coastal-sand"];
+  const surfaceMuted = shade(p.surface, isDark ? 0.04 : -0.04);
   return {
     ...base,
     id: "custom",
@@ -28,7 +29,9 @@ function buildCustomTheme(p: CustomPalette): typeof themesById[string] {
       colors: {
         bg: p.bg,
         surface: p.surface,
-        surfaceMuted: shade(p.surface, isDark ? 0.04 : -0.04),
+        surfaceMuted,
+        // Search field fill: an explicit swatch, else the muted surface.
+        searchBg: p.searchBg || surfaceMuted,
         ink: p.ink,
         inkMuted: shade(p.ink, isDark ? -0.18 : 0.36),
         inkSoft: shade(p.ink, isDark ? -0.36 : 0.55),

--- a/lib/themes/useResolvedTheme.tsx
+++ b/lib/themes/useResolvedTheme.tsx
@@ -19,6 +19,7 @@ function buildCustomTheme(p: CustomPalette): typeof themesById[string] {
   const isDark = p.mode === "dark";
   const base = isDark ? themesById["editorial-dark"] : themesById["coastal-sand"];
   const surfaceMuted = shade(p.surface, isDark ? 0.04 : -0.04);
+  const menuText = p.menuText || p.ink;
   return {
     ...base,
     id: "custom",
@@ -38,6 +39,10 @@ function buildCustomTheme(p: CustomPalette): typeof themesById[string] {
         divider: hexToRgba(p.ink, 0.14),
         // Category-banner text: an explicit swatch, else inherit the body ink.
         categoryInk: p.categoryInk || p.ink,
+        // Item/combo detail-modal text tiers: an explicit swatch, else body ink.
+        menuText,
+        menuTextMuted: shade(menuText, isDark ? -0.18 : 0.36),
+        menuTextSoft: shade(menuText, isDark ? -0.36 : 0.55),
         accent: p.accent,
         accentInk: contrastInk(p.accent),
         success: isDark ? "#88B26A" : "#3A8050",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -667,6 +667,9 @@ export type WebsiteConfig = {
     /** Text color for category banners/dividers. Optional — falls back to `ink`
      *  so existing palettes render identically until an owner sets it. */
     categoryInk?: string;
+    /** Background fill of the search field. Optional — falls back to the muted
+     *  surface so existing palettes are unchanged until an owner sets it. */
+    searchBg?: string;
   };
   /** Optional per-section color overrides layered on top of the active theme.
    *  Any missing section/field inherits the global theme color. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -670,6 +670,9 @@ export type WebsiteConfig = {
     /** Background fill of the search field. Optional — falls back to the muted
      *  surface so existing palettes are unchanged until an owner sets it. */
     searchBg?: string;
+    /** Text color for item/combo detail modals ("fiches"). Optional — falls back
+     *  to `ink` so existing palettes are unchanged until an owner sets it. */
+    menuText?: string;
   };
   /** Optional per-section color overrides layered on top of the active theme.
    *  Any missing section/field inherits the global theme color. */


### PR DESCRIPTION
Bundles the two remaining custom-palette color decouplings (search field was already in these PRs; item-detail text is added on top):

- **Search background** (`searchBg` → `--search-bg`) — search field fill, independent of Surface.
- **Item detail text** (`menuText` → `--menu-text*`) — item/combo detail-modal ("fiche") text, independent of Texte. Also fixes the modals' previously-undefined `--text-primary`/`--text-secondary` variables.

Both fall back to their existing color, so current sites are unchanged until an owner sets the swatch. No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)