### PR TITLE
feat: "Disponible maintenant" section + immediate-cart checkout

### DIFF
--- a/app/order/checkout/page.tsx
+++ b/app/order/checkout/page.tsx
@@ -23,6 +23,7 @@ import {
   fetchMe,
   checkDeliveryAddress,
   fetchDeliveryCities,
+  isImmediateItem,
 } from "@/services/api";
 import { BatchFulfillmentConfigResponse, CheckoutConfig, OrderPayload, OrderType, Restaurant, SchedulingConfigResponse, SchedulingTimeSlot } from "@/lib/types";
 import { formatModifierLabel, isByWeight, lineTotal, lineUnitPrice } from "@/lib/cart";
@@ -255,10 +256,22 @@ function CheckoutContent() {
   // A tour is fulfilled on its own future day, exactly like a scheduled order: it
   // is not gated on today's opening hours or today's sold-out state.
   const futureFulfillment = isTour || isScheduled;
+  // "Disponible maintenant" — the immediate-sale channel. The cart is immediate
+  // when every line is an immediate-sale item in its current window (surplus once
+  // the cutoff has passed, standalone always). Such a cart is fulfilled same-day
+  // and bypasses the batch cutoff; mixing it with pre-order lines is rejected.
+  const batchClosed =
+    !!restaurant?.batchFulfillmentEnabled && !!batchConfig?.enabled && !batchConfig.orderingOpen;
+  const cartIsImmediate =
+    hydrated && lines.length > 0 && lines.every((l) => isImmediateItem(l.item, batchClosed));
+  const cartMixed =
+    lines.some((l) => isImmediateItem(l.item, batchClosed)) && !cartIsImmediate;
   // Scheduled and batch-fulfillment orders target a future date, so today's sold-out
   // state isn't the right gate — mirror the mutation, which skips the real-time check
-  // for them. Leave the per-line map empty so nothing is flagged or blocked.
-  const availabilityCheckEnabled = !futureFulfillment && !restaurant?.batchFulfillmentEnabled;
+  // for them. Leave the per-line map empty so nothing is flagged or blocked. Immediate
+  // carts DO get the real-time check: live count stock is exactly their gate.
+  const availabilityCheckEnabled =
+    (!futureFulfillment && !restaurant?.batchFulfillmentEnabled) || cartIsImmediate;
   const lineAvailability = useMemo(() => {
     const map = new Map<string, LineAvailability>();
     if (!hydrated || !availabilityCheckEnabled) return map;
@@ -399,7 +412,7 @@ function CheckoutContent() {
     </>
   );
 
-  const checkoutBlocked = hasBlockedLines || isBelowMinimum || tourExpired;
+  const checkoutBlocked = hasBlockedLines || isBelowMinimum || tourExpired || cartMixed;
 
   // Normalize phone number with country code
   const normalizePhone = (phone: string) => {
@@ -746,10 +759,12 @@ function CheckoutContent() {
         // The tour's delivery date IS the fulfillment date. The server re-resolves
         // it from the tour and ignores anything else the client sends; keeping the
         // payload honest is what makes the confirmation screen show the right day.
-        isScheduled: isTour ? true : (isScheduled || undefined),
-        scheduledFor: isTour ? tour?.deliveryDate : (isScheduled && scheduledFor ? scheduledFor : undefined),
-        scheduledPickupWindowStart: isTour ? tour?.deliveryStart : (isScheduled && selectedSlot ? selectedSlot.start : undefined),
-        scheduledPickupWindowEnd: isTour ? tour?.deliveryEnd : (isScheduled && selectedSlot ? selectedSlot.end : undefined),
+        // An immediate ("Disponible maintenant") cart is same-day: send no
+        // scheduling fields so the server classifies it as immediate, not batch.
+        isScheduled: cartIsImmediate ? undefined : (isTour ? true : (isScheduled || undefined)),
+        scheduledFor: cartIsImmediate ? undefined : (isTour ? tour?.deliveryDate : (isScheduled && scheduledFor ? scheduledFor : undefined)),
+        scheduledPickupWindowStart: cartIsImmediate ? undefined : (isTour ? tour?.deliveryStart : (isScheduled && selectedSlot ? selectedSlot.start : undefined)),
+        scheduledPickupWindowEnd: cartIsImmediate ? undefined : (isTour ? tour?.deliveryEnd : (isScheduled && selectedSlot ? selectedSlot.end : undefined)),
         items: lines.filter((l) => !l.comboId).map((line) => ({
           itemId: line.item.id,
           quantity: line.quantity,
@@ -1299,7 +1314,11 @@ function CheckoutContent() {
                       hero pill; this block is the per-order confirmation. */}
                   {!isTour && (orderType === "pickup" || orderType === "delivery") && restaurant?.batchFulfillmentEnabled && batchConfig?.enabled && (
                     <div className="p-4 bg-amber-50 border border-amber-200 rounded-xl space-y-2">
-                      {batchConfig.orderingOpen ? (
+                      {cartIsImmediate ? (
+                        <p className="text-sm font-semibold text-amber-800">
+                          {t("immediatePickupToday")}
+                        </p>
+                      ) : batchConfig.orderingOpen ? (
                         <>
                           <p className="text-sm font-semibold text-amber-800">
                             {orderType === "delivery" ? t("batchDeliveryInfo") : t("batchPickupInfo")}
@@ -1335,6 +1354,7 @@ function CheckoutContent() {
                       ) : (
                         <p className="text-sm text-amber-700">
                           {t("batchOrderingClosed")}
+                          {cartMixed ? " " + t("immediateMixedHint") : ""}
                         </p>
                       )}
                     </div>
@@ -1475,8 +1495,11 @@ function CheckoutContent() {
                     disabled={
                       sendOtpMutation.isPending ||
                       tourExpired ||
+                      cartMixed ||
                       (isScheduled && (!scheduledFor || !selectedSlot)) ||
-                      (!isTour && restaurant?.batchFulfillmentEnabled && batchConfig?.enabled && !batchConfig.orderingOpen)
+                      // The batch cutoff blocks pre-order carts, but an all-immediate
+                      // ("Disponible maintenant") cart is sold same-day past the cutoff.
+                      (!isTour && !cartIsImmediate && restaurant?.batchFulfillmentEnabled && batchConfig?.enabled && !batchConfig.orderingOpen)
                     }
                     className="w-full py-4 rounded-xl bg-brand text-white font-bold shadow-lg shadow-brand/30 hover:bg-brand-dark transition disabled:opacity-50"
                   >
@@ -1893,6 +1916,7 @@ function CheckoutContent() {
               ? { scheduledFor, selectedSlot }
               : null
           }
+          cartLineSaleModes={lines.map((l) => l.item.immediateSaleMode ?? "")}
           onConfirm={handleOrderDetailsConfirm}
         />
       )}

--- a/components/OrderDetailsModal.tsx
+++ b/components/OrderDetailsModal.tsx
@@ -37,6 +37,10 @@ type Props = {
   orderType: OrderType;
   /** Pre-existing scheduling selection (e.g. carried over from a previous open). */
   initialSchedulingIntent?: SchedulingIntent | null;
+  /** The immediate-sale mode of each cart line ('' | 'surplus' | 'standalone').
+   *  Used to detect a "Disponible maintenant" cart, which is fulfilled same-day
+   *  and skips the batch collection-day picker. */
+  cartLineSaleModes?: string[];
   /** Called when the user taps Done/Confirm. */
   onConfirm: (orderType: OrderType, intent: SchedulingIntent | null) => void;
 };
@@ -48,6 +52,7 @@ export function OrderDetailsModal({
   currency,
   orderType: initialOrderType,
   initialSchedulingIntent,
+  cartLineSaleModes = [],
   onConfirm,
 }: Props) {
   const { t, locale } = useI18n();
@@ -153,6 +158,14 @@ export function OrderDetailsModal({
 
   const selectedBatchDay = eligibleBatchDays.find((d) => d.date === batchDay) ?? null;
 
+  // A "Disponible maintenant" cart: every line is an immediate-sale item in its
+  // current window (standalone always, surplus once the cutoff has passed). Such
+  // a cart is same-day and skips the batch collection-day picker entirely.
+  const orderingClosed = !!batchConfig && !batchConfig.orderingOpen;
+  const cartIsImmediate =
+    cartLineSaleModes.length > 0 &&
+    cartLineSaleModes.every((m) => m === "standalone" || (m === "surplus" && orderingClosed));
+
   const handleOrderTypeChange = (type: OrderType) => {
     setLocalOrderType(type);
     // Reset scheduling state when switching type so config is re-fetched for the new type
@@ -180,7 +193,10 @@ export function OrderDetailsModal({
   const canConfirmSchedule = scheduledFor !== null && selectedSlot !== null;
 
   const handleDone = () => {
-    if (isBatchMode) {
+    if (cartIsImmediate) {
+      // Same-day immediate sale: no scheduling, no batch day.
+      onConfirm(localOrderType, null);
+    } else if (isBatchMode) {
       // Batch orders are always scheduled — the only question is which day of the
       // lot. Sending the day lets the server honour it instead of defaulting to the
       // first one; the server re-validates it against the live cycle either way.
@@ -299,6 +315,10 @@ export function OrderDetailsModal({
                     {batchLoading ? (
                       <div className="text-center text-[var(--text-muted)] animate-pulse py-4">
                         {t("loadingFulfillmentSchedule")}
+                      </div>
+                    ) : cartIsImmediate ? (
+                      <div className="rounded-2xl border-2 border-emerald-500 bg-emerald-500/5 p-4">
+                        <p className="font-semibold text-emerald-700">{t("immediatePickupToday")}</p>
                       </div>
                     ) : batchConfig && !batchConfig.orderingOpen ? (
                       <div className="rounded-2xl border-2 border-amber-500 bg-amber-500/5 p-4">
@@ -427,7 +447,7 @@ export function OrderDetailsModal({
                 <div className="px-6 pt-4 pb-8">
                   <button
                     onClick={handleDone}
-                    disabled={isBatchMode && batchConfig !== null && !batchConfig.orderingOpen}
+                    disabled={!cartIsImmediate && isBatchMode && batchConfig !== null && !batchConfig.orderingOpen}
                     className="w-full py-4 rounded-2xl bg-brand text-white font-bold text-base shadow-lg shadow-brand/25 hover:bg-brand-dark transition disabled:opacity-50"
                   >
                     {t("done")}

--- a/components/OrderExperience.tsx
+++ b/components/OrderExperience.tsx
@@ -1508,6 +1508,7 @@ export function OrderExperience({ menu, restaurant, initialOrderType, tableId, s
         currency={menu.currency}
         orderType={orderType}
         initialSchedulingIntent={schedulingIntent}
+        cartLineSaleModes={lines.map((l) => l.item.immediateSaleMode ?? "")}
         onConfirm={(newOrderType, intent) => {
           setOrderType(newOrderType);
           setSchedulingIntent(intent);

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -392,6 +392,8 @@ const translations: Record<Locale, Record<string, string>> = {
     batchOrderingCloses: "Ordering closes",
     batchOrderingClosesAt: "at",
     batchOrderingClosed: "Ordering for this batch has closed. Please check back when the next ordering window opens.",
+    immediatePickupToday: "Same-day pickup, ready today while stock lasts.",
+    immediateMixedHint: "Some items are still available now for same-day pickup.",
     // Batch ordering banner (menu page + checkout)
     forPickup: "for pickup",
     forDelivery: "for delivery",
@@ -955,6 +957,8 @@ const translations: Record<Locale, Record<string, string>> = {
     batchOrderingCloses: "ההזמנות נסגרות",
     batchOrderingClosesAt: "ב",
     batchOrderingClosed: "ההזמנות לסבב זה נסגרו. בדוק שוב כשחלון ההזמנות הבא ייפתח.",
+    immediatePickupToday: "איסוף באותו יום, בכפוף למלאי הקיים.",
+    immediateMixedHint: "חלק מהפריטים עדיין זמינים כעת לאיסוף באותו יום.",
     // Batch ordering banner (menu page + checkout)
     forPickup: "לאיסוף",
     forDelivery: "למשלוח",
@@ -1517,6 +1521,8 @@ const translations: Record<Locale, Record<string, string>> = {
     batchOrderingCloses: "Les commandes ferment",
     batchOrderingClosesAt: "à",
     batchOrderingClosed: "Les commandes pour ce lot sont fermées. Revenez à l'ouverture de la prochaine fenêtre de commande.",
+    immediatePickupToday: "Retrait aujourd'hui, dans la limite du stock disponible.",
+    immediateMixedHint: "Certains articles restent disponibles maintenant en retrait le jour même.",
     // Batch ordering banner (menu page + checkout)
     forPickup: "pour retrait",
     forDelivery: "pour livraison",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -75,6 +75,10 @@ export type MenuItem = {
   availabilityState?: 'available' | 'low' | 'sold_out' | 'hidden';
   /** Portions still buildable, when the assigned rule chooses to show it. */
   buildableCount?: number | null;
+  /** Immediate-sale channel ("Disponible maintenant"). '' = pre-order only;
+   *  'surplus' = pre-orderable in the lot, then same-day sellable after the
+   *  cutoff; 'standalone' = same-day only, never in the pre-order lot. */
+  immediateSaleMode?: '' | 'surplus' | 'standalone';
   comboOnly?: boolean;
   /** Item type: 'food_and_beverage' (default) or 'combo'. */
   itemType?: ItemType;

--- a/services/api.ts
+++ b/services/api.ts
@@ -27,6 +27,25 @@ import { useGuestAccount } from "@/store/useGuestAccount";
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
 const API_PREFIX = `${API_BASE}/api/v1`;
 const PUBLIC_PREFIX = `${API_PREFIX}/public`;
+
+/** Synthetic group id for the "Disponible maintenant" (immediate-sale) section.
+ *  Its items carry this as `groupId`; the checkout classifies a cart as immediate
+ *  when every line is an immediate-sale item (see `isImmediateItem`). */
+export const IMMEDIATE_GROUP_ID = "immediate-now";
+
+/** True when an item is sold through the immediate ("Disponible maintenant")
+ *  channel right now. Standalone items always are; surplus items only once the
+ *  batch ordering window has closed. Mirrors the server classifier so the web
+ *  never lets a mixed / out-of-window cart reach checkout. */
+export function isImmediateItem(
+  item: { immediateSaleMode?: string } | undefined,
+  orderingClosed: boolean,
+): boolean {
+  const mode = item?.immediateSaleMode ?? "";
+  if (mode === "standalone") return true;
+  if (mode === "surplus") return orderingClosed;
+  return false;
+}
 const WS_BASE = process.env.NEXT_PUBLIC_WS_BASE_URL ?? API_BASE.replace(/^http/, "ws");
 const API_TOKEN = process.env.NEXT_PUBLIC_API_TOKEN;
 
@@ -333,7 +352,7 @@ function _mapModifierSets(rawSets: any[]): ModifierSet[] {
   return result;
 }
 
-function _mapCategories(rawCats: Array<{ id: number; name?: string; Name?: string; items?: any[]; Items?: any[] }>) {
+function _mapCategories(rawCats: Array<{ id: number | string; name?: string; Name?: string; items?: any[]; Items?: any[]; translations?: any; Translations?: any }>) {
   const categories = rawCats.map((c: any) => ({
     id: String(c.id),
     name: c.name || c.Name || "Category",
@@ -358,6 +377,7 @@ function _mapCategories(rawCats: Array<{ id: number; name?: string; Name?: strin
       available: item.is_active ?? item.IsActive ?? true,
       availabilityState: item.availability_state || undefined,
       buildableCount: item.buildable_count ?? null,
+      immediateSaleMode: item.immediate_sale_mode || '',
       comboOnly: item.combo_only ?? false,
       allowNotes: item.allow_notes ?? null,
       comboAllowQuantity: item.combo_allow_quantity == null ? undefined : Boolean(item.combo_allow_quantity),
@@ -456,6 +476,11 @@ export async function fetchMenu(
   const data = await handleResponse<{
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     menus: Array<{ id: number; name: string; groups?: any[]; categories?: any[] }>;
+    // Items sellable for same-day immediate pickup right now ("Disponible
+    // maintenant"): surplus after the batch cutoff + standalone shop items, gated
+    // by live count stock. Independent of the pre-order rotation/série filters.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    immediate_items?: any[];
   }>(res);
 
   const menus = (data.menus ?? []).map((m) => {
@@ -470,6 +495,33 @@ export async function fetchMenu(
     const entryKey = `menu-${m.id}`;
     return { entryKey, id: m.id, name: m.name, groups, categories: groups, items };
   });
+
+  // "Disponible maintenant" — surface the immediate-sale items as a synthetic
+  // group at the top of the first carte so they render (and are addable) even
+  // when the pre-order window is closed. Kept out of the pre-order groups by the
+  // server, so no item is duplicated.
+  const rawImmediate = data.immediate_items ?? [];
+  if (rawImmediate.length > 0 && menus.length > 0) {
+    const { categories: immGroups, items: immItems } = _mapCategories([
+      {
+        id: IMMEDIATE_GROUP_ID,
+        name: "Disponible maintenant",
+        translations: {
+          name: { en: "Available now", he: "זמין עכשיו", fr: "Disponible maintenant" },
+        },
+        items: rawImmediate,
+      },
+    ]);
+    if (immGroups.length > 0) {
+      const g = immGroups[0];
+      menus[0] = {
+        ...menus[0],
+        groups: [g, ...menus[0].groups],
+        categories: [g, ...menus[0].categories],
+        items: [...immItems, ...menus[0].items],
+      };
+    }
+  }
 
   // Flat lists for backward compat (single-menu rendering still works). They double
   // as a global lookup-by-id table; a carte shared by several menus would otherwise


### PR DESCRIPTION
Guest-web side of the "Disponible maintenant" + per-item lead-time feature. Server PR: Foody-isr/server#163. Admin PR: Foody-isr/admin#189.

## What
- `fetchMenu` parses `immediate_items` and injects them as a synthetic **"Disponible maintenant"** group at the top of the first carte, so leftover items render (and are addable) even when the pre-order window is closed. `isImmediateItem()` mirrors the server classifier.
- Checkout: an **all-immediate** cart can check out past the batch cutoff (same-day pickup); **mixed** carts (immediate + pre-order) are blocked with a message; immediate carts send no scheduling fields and get the real-time stock check.
- `OrderDetailsModal` skips the batch collection-day picker for an immediate cart (via a new `cartLineSaleModes` prop) and shows a same-day note.
- i18n en/he/fr.

## Validation
`npx tsc --noEmit` ✓, `npm run lint` ✓ (only pre-existing warnings), `next build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)